### PR TITLE
[PAM-C] Improve CPU performance

### DIFF
--- a/dynamics/spam/src/hamiltonians/compressible_euler.h
+++ b/dynamics/spam/src/hamiltonians/compressible_euler.h
@@ -30,7 +30,7 @@ public:
 
   void set_parameters(real gin) {}
 
-  real YAKL_INLINE compute_PE(const real5d dens, const real5d geop, int is,
+  real YAKL_INLINE compute_PE(const real5d &dens, const real5d &geop, int is,
                               int js, int ks, int i, int j, int k,
                               int n) const {
     SArray<real, 1, 1> geop0;
@@ -46,7 +46,7 @@ public:
     return dens(0, k + ks, j + js, i + is, n) * geop0(0);
   }
 
-  real YAKL_INLINE compute_IE(const real5d dens, int is, int js, int ks, int i,
+  real YAKL_INLINE compute_IE(const real5d &dens, int is, int js, int ks, int i,
                               int j, int k, int n) const {
     // SArray<real,1,2> dens0;
     // #ifdef _EXTRUDED
@@ -63,9 +63,10 @@ public:
   }
 
   template <ADD_MODE addmode = ADD_MODE::REPLACE>
-  void YAKL_INLINE compute_dHsdx(real5d B, const real5d dens, const real5d geop,
-                                 int is, int js, int ks, int i, int j, int k,
-                                 int n, real fac = 1._fp) const {
+  void YAKL_INLINE compute_dHsdx(const real5d &B, const real5d &dens,
+                                 const real5d &geop, int is, int js, int ks,
+                                 int i, int j, int k, int n,
+                                 real fac = 1._fp) const {
 
     SArray<real, 1, 1> geop0;
 #ifdef _EXTRUDED
@@ -139,7 +140,7 @@ public:
 
   void set_parameters(real gin) {}
 
-  real YAKL_INLINE compute_PE(const real5d dens, const real5d geop, int is,
+  real YAKL_INLINE compute_PE(const real5d &dens, const real5d &geop, int is,
                               int js, int ks, int i, int j, int k,
                               int n) const {
     SArray<real, 1, 1> geop0;
@@ -156,7 +157,7 @@ public:
     return dens(0, k + ks, j + js, i + is, n) * geop0(0);
   }
 
-  real YAKL_INLINE compute_IE(const real5d dens, int is, int js, int ks, int i,
+  real YAKL_INLINE compute_IE(const real5d &dens, int is, int js, int ks, int i,
                               int j, int k, int n) const {
 
     // SArray<real,1,5> dens0;
@@ -185,9 +186,10 @@ public:
 
   // THIS NEEDS FIXING, BUT SHOULD BE COMPLETELY GENERAL NOW!
   template <ADD_MODE addmode = ADD_MODE::REPLACE>
-  void YAKL_INLINE compute_dHsdx(real5d B, const real5d dens, const real5d geop,
-                                 int is, int js, int ks, int i, int j, int k,
-                                 int n, real fac = 1._fp) const {
+  void YAKL_INLINE compute_dHsdx(const real5d &B, const real5d &dens,
+                                 const real5d &geop, int is, int js, int ks,
+                                 int i, int j, int k, int n,
+                                 real fac = 1._fp) const {
 
     SArray<real, 1, 1> geop0;
 
@@ -303,8 +305,8 @@ public:
 //  }
 //
 //
-//  real YAKL_INLINE compute_PE(const real5d dens, const real5d densfct, const
-//  real5d geop, int is, int js, int ks, int i, int j, int k)
+//  real YAKL_INLINE compute_PE(const real5d& dens, const real5d& densfct, const
+//  const real5d& geop, int is, int js, int ks, int i, int j, int k)
 //  {
 //
 //    SArray<real,1,1> geop0;
@@ -323,37 +325,37 @@ public:
 //  //   ql = rho_l/rho;
 //  //   qi = rho_i/rho;
 //  // with rho = rho_d + rho_v + rho_l + rho_i
-//      real YAKL_INLINE compute_alpha(const real5d dens0, const real5d
+//      real YAKL_INLINE compute_alpha(const real5d& dens0, const real5d&
 //      densfct0, int is, int js, int ks, int i, int j, int k, int n) {
 //        return 1./(dens0(0, k+ks, j+js, i+is) + densfct0(0, k+ks, j+js, i+is)
 //        + densfct0(1, k+ks, j+js, i+is) + densfct0(2, k+ks, j+js, i+is));
 //      }
 //
-//      real YAKL_INLINE compute_entropic_var(const real5d dens0, const real5d
+//      real YAKL_INLINE compute_entropic_var(const real5d& dens0, const real5d&
 //      densfct0, int is, int js, int ks, int i, int j, int k, int n) {
 //        return dens0(1, k+ks, j+js, i+is)/(dens0(0, k+ks, j+js, i+is) +
 //        densfct0(0, k+ks, j+js, i+is) + densfct0(1, k+ks, j+js, i+is) +
 //        densfct0(2, k+ks, j+js, i+is));
 //      }
-//      real YAKL_INLINE compute_qd(const real5d dens0, const real5d densfct0,
+//      real YAKL_INLINE compute_qd(const real5d& dens0, const real5d& densfct0,
 //      int is, int js, int ks, int i, int j, int k, int n) {
 //        return (dens0(0, k+ks, j+js, i+is))/(dens0(0, k+ks, j+js, i+is) +
 //        densfct0(0, k+ks, j+js, i+is) + densfct0(1, k+ks, j+js, i+is) +
 //        densfct0(2, k+ks, j+js, i+is));
 //      }
-//      real YAKL_INLINE compute_qv(const real5d dens0, const real5d densfct0,
+//      real YAKL_INLINE compute_qv(const real5d& dens0, const real5d& densfct0,
 //      int is, int js, int ks, int i, int j, int k, int n) {
 //        return densfct0(0, k+ks, j+js, i+is)/(dens0(0, k+ks, j+js, i+is) +
 //        densfct0(0, k+ks, j+js, i+is) + densfct0(1, k+ks, j+js, i+is) +
 //        densfct0(2, k+ks, j+js, i+is));
 //      }
-//      real YAKL_INLINE compute_ql(const real5d dens0, const real5d densfct0,
+//      real YAKL_INLINE compute_ql(const real5d& dens0, const real5d& densfct0,
 //      int is, int js, int ks, int i, int j, int k, int n) {
 //        return densfct0(1, k+ks, j+js, i+is)/(dens0(0, k+ks, j+js, i+is) +
 //        densfct0(0, k+ks, j+js, i+is) + densfct0(1, k+ks, j+js, i+is) +
 //        densfct0(2, k+ks, j+js, i+is));
 //      }
-//      real YAKL_INLINE compute_qi(const real5d dens0, const real5d densfct0,
+//      real YAKL_INLINE compute_qi(const real5d& dens0, const real5d& densfct0,
 //      int is, int js, int ks, int i, int j, int k, int n) {
 //        return densfct0(2, k+ks, j+js, i+is)/(dens0(0, k+ks, j+js, i+is) +
 //        densfct0(0, k+ks, j+js, i+is) + densfct0(1, k+ks, j+js, i+is) +
@@ -361,8 +363,8 @@ public:
 //      }
 //
 //
-//  real YAKL_INLINE compute_IE(const real5d dens, const real5d densfct, int is,
-//  int js, int ks, int i, int j, int k, int n)
+//  real YAKL_INLINE compute_IE(const real5d& dens, const real5d& densfct, int
+//  is, int js, int ks, int i, int j, int k, int n)
 //  {
 //
 //    SArray<real,1,2> dens0;
@@ -377,9 +379,9 @@ public:
 //    return rho * thermo.compute_U(alpha, entropic_var, qd, qv, ql, qi);
 //  }
 //
-//   void YAKL_INLINE compute_dHsdx(real5d B, real5d Bfct, const real5d dens0,
-//   const real5d densfct0, const real5d geop, int is, int js, int ks, int i,
-//   int j, int k, int n)
+//   void YAKL_INLINE compute_dHsdx(const real5d& B, const real5d& Bfct, const
+//   real5d& dens0, const real5d& densfct0, const real5d& geop, int is, int js,
+//   int ks, int i, int j, int k, int n)
 //   {
 //
 //     SArray<real,1,1> geop0;
@@ -422,7 +424,7 @@ public:
 // p-variants
 // class Hamiltonian_CE_p_Hs : public Hamiltonian_CE_Hs
 // {
-//   real YAKL_INLINE compute_IE(const real5d dens, const real5d densfct, int
+//   real YAKL_INLINE compute_IE(const real5d& dens, const real5d& densfct, int
 //   is, int js, int ks, int i, int j, int k)
 //   {
 //     SArray<real,2> dens0;
@@ -433,9 +435,9 @@ public:
 //     entropic_var, 0, 0, 0, 0) - p;
 //   }
 //
-//    void YAKL_INLINE compute_dHsdx(real5d B, real5d Bfct, const real5d dens0,
-//    const real5d densfct0, const real5d geop, int is, int js, int ks, int i,
-//    int j, int k)
+//    void YAKL_INLINE compute_dHsdx(const real5d& B, const real5d& Bfct, const
+//    real5d& dens0, const real5d& densfct0, const real5d& geop, int is, int js,
+//    int ks, int i, int j, int k)
 //    {
 //
 //      SArray<real,1> geop0;
@@ -458,7 +460,7 @@ public:
 //
 // class Hamiltonian_MCE_rho_p_Hs : public Hamiltonian_MCE_rho_Hs
 // {
-//   real YAKL_INLINE compute_IE(const real5d dens, const real5d densfct, int
+//   real YAKL_INLINE compute_IE(const real5d& dens, const real5d& densfct, int
 //   is, int js, int ks, int i, int j, int k)
 //   {
 //
@@ -479,9 +481,9 @@ public:
 //     qv, ql, qi) - p;
 //   }
 //
-//    void YAKL_INLINE compute_dHsdx(real5d B, real5d Bfct, const real5d dens0,
-//    const real5d densfct0, const real5d geop, int is, int js, int ks, int i,
-//    int j, int k)
+//    void YAKL_INLINE compute_dHsdx(const real5d& B, const real5d& Bfct, const
+//    real5d& dens0, const real5d& densfct0, const real5d& geop, int is, int js,
+//    int ks, int i, int j, int k)
 //    {
 //
 //      SArray<real,1> geop0;
@@ -522,7 +524,7 @@ public:
 //
 // class Hamiltonian_MCE_rhod_p_Hs : public Hamiltonian_MCE_rhod_Hs
 // {
-//   real YAKL_INLINE compute_IE(const real5d dens, const real5d densfct, int
+//   real YAKL_INLINE compute_IE(const real5d& dens, const real5d& densfct, int
 //   is, int js, int ks, int i, int j, int k)
 //   {
 //
@@ -543,9 +545,9 @@ public:
 //     return rho * thermo.compute_H(p, entropic_var, qd, qv, ql, qi) - p;
 //   }
 //
-//    void YAKL_INLINE compute_dHsdx(real5d B, real5d Bfct, const real5d dens0,
-//    const real5d densfct0, const real5d geop, int is, int js, int ks, int i,
-//    int j, int k)
+//    void YAKL_INLINE compute_dHsdx(const real5d& B, const real5d& Bfct, const
+//    real5d& dens0, const real5d& densfct0, const real5d& geop, int is, int js,
+//    int ks, int i, int j, int k)
 //    {
 //
 //      SArray<real,1> geop0;

--- a/dynamics/spam/src/hamiltonians/functionals.h
+++ b/dynamics/spam/src/hamiltonians/functionals.h
@@ -22,7 +22,7 @@ public:
     this->varset = variableset;
   }
 
-  real YAKL_INLINE compute_hv(const real5d dens, int is, int js, int ks, int i,
+  real YAKL_INLINE compute_hv(const real5d &dens, int is, int js, int ks, int i,
                               int j, int k, int n) const {
     SArray<real, 1, 1> hv;
     SArray<real, 1, 4> Dv;
@@ -37,7 +37,7 @@ public:
     return hv(0);
   }
 
-  real YAKL_INLINE compute_zeta(const real5d v, int is, int js, int ks, int i,
+  real YAKL_INLINE compute_zeta(const real5d &v, int is, int js, int ks, int i,
                                 int j, int k, int n) const {
     SArray<real, 1, 1> zeta;
     // compute zeta = D2 v
@@ -45,7 +45,7 @@ public:
     return zeta(0);
   }
 
-  real YAKL_INLINE compute_eta(const real5d v, const real5d coriolis, int is,
+  real YAKL_INLINE compute_eta(const real5d &v, const real5d &coriolis, int is,
                                int js, int ks, int i, int j, int k,
                                int n) const {
     real zeta = compute_zeta(v, is, js, ks, i, j, k, n);
@@ -53,10 +53,10 @@ public:
   }
 
   // This computes relative q0
-  void YAKL_INLINE compute_q0f0(real5d q0, real5d f0, const real5d v,
-                                const real5d dens, const real5d coriolis,
-                                int is, int js, int ks, int i, int j, int k,
-                                int n) const {
+  void YAKL_INLINE compute_q0f0(const real5d &q0, const real5d &f0,
+                                const real5d &v, const real5d &dens,
+                                const real5d &coriolis, int is, int js, int ks,
+                                int i, int j, int k, int n) const {
 
     real hv = compute_hv(dens, is, js, ks, i, j, k, n);
     real zeta = compute_zeta(v, is, js, ks, i, j, k, n);
@@ -68,17 +68,18 @@ public:
   }
 
   // This computes TRUE q0
-  void YAKL_INLINE compute_q0(real5d q0, const real5d v, const real5d dens,
-                              const real5d coriolis, int is, int js, int ks,
-                              int i, int j, int k, int n) const {
+  void YAKL_INLINE compute_q0(const real5d &q0, const real5d &v,
+                              const real5d &dens, const real5d &coriolis,
+                              int is, int js, int ks, int i, int j, int k,
+                              int n) const {
     real hv = compute_hv(dens, is, js, ks, i, j, k, n);
     real eta = compute_eta(v, coriolis, is, js, ks, i, j, k, n);
     // compute q0 = zeta / hv and f0 = f / hv
     q0(0, k + ks, j + js, i + is, n) = eta / hv;
   }
 
-  pvpe YAKL_INLINE compute_PVPE(const real5d v, const real5d dens,
-                                const real5d coriolis, int is, int js, int ks,
+  pvpe YAKL_INLINE compute_PVPE(const real5d &v, const real5d &dens,
+                                const real5d &coriolis, int is, int js, int ks,
                                 int i, int j, int k, int n) const {
     pvpe vals;
     real eta = compute_eta(v, coriolis, is, js, ks, i, j, k, n);
@@ -106,8 +107,8 @@ public:
 //   this->is_initialized = true;
 // }
 //
-// real YAKL_INLINE compute_hv(const real5d dens, const real5d densfct, int is,
-// int js, int ks, int i, int j, int k)
+// real YAKL_INLINE compute_hv(const real5d& dens, const real5d& densfct, int
+// is, int js, int ks, int i, int j, int k)
 // {
 //   SArray<real,1> hv;
 //   SArray<real,4> Dv;
@@ -126,7 +127,7 @@ public:
 //   return hv(0);
 // }
 //
-// real YAKL_INLINE compute_zeta(const real5d v, int is, int js, int ks, int i,
+// real YAKL_INLINE compute_zeta(const real5d& v, int is, int js, int ks, int i,
 // int j, int k)
 // {
 //   SArray<real,1> zeta;
@@ -135,7 +136,7 @@ public:
 //   return zeta(0);
 // }
 //
-// real YAKL_INLINE compute_eta(const real5d v, const real5d coriolis, int is,
+// real YAKL_INLINE compute_eta(const real5d& v, const real5d& coriolis, int is,
 // int js, int ks, int i, int j, int k)
 // {
 //   real zeta = compute_zeta(v, is, js, ks, i, j, k);
@@ -143,9 +144,9 @@ public:
 // }
 //
 //
-// void YAKL_INLINE compute_q0f0(real5d q0, real5d f0, const real5d v, const
-// real5d dens, const real5d densfct, const real5d coriolis, int is, int js, int
-// ks, int i, int j, int k)
+// void YAKL_INLINE compute_q0f0(const real5d& q0, const real5d& f0, const
+// real5d& v, const const real5d& dens, const real5d& densfct, const real5d&
+// coriolis, int is, int js, int ks, int i, int j, int k)
 // {
 //
 //   real hv = compute_hv(dens, densfct, is, js, ks, i, j, k);
@@ -157,8 +158,8 @@ public:
 //
 // }
 //
-// void YAKL_INLINE compute_q0(real5d q0, const real5d v, const real5d dens,
-// const real5d densfct, int is, int js, int ks, int i, int j, int k)
+// void YAKL_INLINE compute_q0(const real5d& q0, const real5d& v, const real5d&
+// dens, const real5d& densfct, int is, int js, int ks, int i, int j, int k)
 // {
 // real hv = compute_hv(dens, densfct, is, js, ks, i, j, k);
 // real zeta = compute_zeta(v, is, js, ks, i, j, k);
@@ -166,8 +167,9 @@ public:
 //   q0(0, k+ks, j+js, i+is) = zeta / hv;
 // }
 //
-// pvpe YAKL_INLINE compute_PVPE(const real5d v, const real5d dens, const real5d
-// densfct, const real5d coriolis, int is, int js, int ks, int i, int j, int k)
+// pvpe YAKL_INLINE compute_PVPE(const real5d& v, const real5d& dens, const
+// real5d& densfct, const real5d& coriolis, int is, int js, int ks, int i, int
+// j, int k)
 // {
 //   pvpe vals;
 //   real eta = compute_eta(v, coriolis, is, js, ks, i, j, k);
@@ -197,7 +199,7 @@ public:
     this->varset = variableset;
   }
 
-  real YAKL_INLINE compute_hvxz(const real5d dens, int is, int js, int ks,
+  real YAKL_INLINE compute_hvxz(const real5d &dens, int is, int js, int ks,
                                 int i, int j, int k, int n) const {
     SArray<real, 1, 1> hv;
     SArray<real, 1, 4> Dv;
@@ -213,7 +215,7 @@ public:
     return hv(0);
   }
 
-  real YAKL_INLINE compute_hvxz_top(const real5d dens, int is, int js, int ks,
+  real YAKL_INLINE compute_hvxz_top(const real5d &dens, int is, int js, int ks,
                                     int i, int j, int k, int n) const {
     SArray<real, 1, 1> hv;
     SArray<real, 1, 4> Dv;
@@ -229,7 +231,7 @@ public:
     return hv(0);
   }
 
-  real YAKL_INLINE compute_hvxz_bottom(const real5d dens, int is, int js,
+  real YAKL_INLINE compute_hvxz_bottom(const real5d &dens, int is, int js,
                                        int ks, int i, int j, int k,
                                        int n) const {
     SArray<real, 1, 1> hv;
@@ -246,7 +248,7 @@ public:
     return hv(0);
   }
 
-  real YAKL_INLINE compute_zetaxz(const real5d v, const real5d w, int is,
+  real YAKL_INLINE compute_zetaxz(const real5d &v, const real5d &w, int is,
                                   int js, int ks, int i, int j, int k,
                                   int n) const {
     SArray<real, 1, 1> zeta;
@@ -255,18 +257,18 @@ public:
     return zeta(0);
   }
 
-  real YAKL_INLINE compute_etaxz(const real5d v, const real5d w,
-                                 const real5d coriolisxz, int is, int js,
+  real YAKL_INLINE compute_etaxz(const real5d &v, const real5d &w,
+                                 const real5d &coriolisxz, int is, int js,
                                  int ks, int i, int j, int k, int n) const {
     real zeta = compute_zetaxz(v, w, is, js, ks, i, j, k, n);
     return zeta + coriolisxz(0, k + ks, j + js, i + is, n);
   }
 
   // This computes true qxz
-  void YAKL_INLINE compute_qxz0(real5d qxz0, const real5d v, const real5d w,
-                                const real5d dens, const real5d coriolisxz,
-                                int is, int js, int ks, int i, int j, int k,
-                                int n) const {
+  void YAKL_INLINE compute_qxz0(const real5d &qxz0, const real5d &v,
+                                const real5d &w, const real5d &dens,
+                                const real5d &coriolisxz, int is, int js,
+                                int ks, int i, int j, int k, int n) const {
     // Need to subtract 1 here since d00(i,k) corresponds to p11(i,k)
     real hv = compute_hvxz(dens, is, js, ks, i, j, k - 1, n);
     real eta = compute_etaxz(v, w, coriolisxz, is, js, ks, i, j, k - 1, n);
@@ -275,10 +277,10 @@ public:
   }
 
   // This computes true qxz
-  void YAKL_INLINE compute_qxz0_top(real5d qxz0, const real5d v, const real5d w,
-                                    const real5d dens, const real5d coriolisxz,
-                                    int is, int js, int ks, int i, int j, int k,
-                                    int n) const {
+  void YAKL_INLINE compute_qxz0_top(const real5d &qxz0, const real5d &v,
+                                    const real5d &w, const real5d &dens,
+                                    const real5d &coriolisxz, int is, int js,
+                                    int ks, int i, int j, int k, int n) const {
     // Need to subtract 1 here since d00(i,k) corresponds to p11(i,k)
     real hv = compute_hvxz_top(dens, is, js, ks, i, j, k - 1, n);
     real eta = compute_etaxz(v, w, coriolisxz, is, js, ks, i, j, k - 1, n);
@@ -287,9 +289,9 @@ public:
   }
 
   // This computes true qxz
-  void YAKL_INLINE compute_qxz0_bottom(real5d qxz0, const real5d v,
-                                       const real5d w, const real5d dens,
-                                       const real5d coriolisxz, int is, int js,
+  void YAKL_INLINE compute_qxz0_bottom(const real5d &qxz0, const real5d &v,
+                                       const real5d &w, const real5d &dens,
+                                       const real5d &coriolisxz, int is, int js,
                                        int ks, int i, int j, int k,
                                        int n) const {
     // Need to subtract 1 here since d00(i,k) corresponds to p11(i,k)
@@ -300,9 +302,10 @@ public:
   }
 
   // This computes relative qxz
-  void YAKL_INLINE compute_qxz0fxz0(real5d qxz0, real5d fxz0, const real5d v,
-                                    const real5d w, const real5d dens,
-                                    const real5d coriolisxz, int is, int js,
+  void YAKL_INLINE compute_qxz0fxz0(const real5d &qxz0, const real5d &fxz0,
+                                    const real5d &v, const real5d &w,
+                                    const real5d &dens,
+                                    const real5d &coriolisxz, int is, int js,
                                     int ks, int i, int j, int k, int n) const {
     // Need to subtract 1 here since d00(i,k) corresponds to p11(i,k)
     real hv = compute_hvxz(dens, is, js, ks, i, j, k - 1, n);
@@ -314,11 +317,11 @@ public:
   }
 
   // This computes relative qxz
-  void YAKL_INLINE compute_qxz0fxz0_top(real5d qxz0, real5d fxz0,
-                                        const real5d v, const real5d w,
-                                        const real5d dens,
-                                        const real5d coriolisxz, int is, int js,
-                                        int ks, int i, int j, int k,
+  void YAKL_INLINE compute_qxz0fxz0_top(const real5d &qxz0, const real5d &fxz0,
+                                        const real5d &v, const real5d &w,
+                                        const real5d &dens,
+                                        const real5d &coriolisxz, int is,
+                                        int js, int ks, int i, int j, int k,
                                         int n) const {
     // Need to subtract 1 here since d00(i,k) corresponds to p11(i,k)
     real hv = compute_hvxz_top(dens, is, js, ks, i, j, k - 1, n);
@@ -330,10 +333,10 @@ public:
   }
 
   // This computes relative qxz
-  void YAKL_INLINE compute_qxz0fxz0_bottom(real5d qxz0, real5d fxz0,
-                                           const real5d v, const real5d w,
-                                           const real5d dens,
-                                           const real5d coriolisxz, int is,
+  void YAKL_INLINE compute_qxz0fxz0_bottom(const real5d &qxz0,
+                                           const real5d &fxz0, const real5d &v,
+                                           const real5d &w, const real5d &dens,
+                                           const real5d &coriolisxz, int is,
                                            int js, int ks, int i, int j, int k,
                                            int n) const {
     // Need to subtract 1 here since d00(i,k) corresponds to p11(i,k)
@@ -345,8 +348,8 @@ public:
         coriolisxz(0, k + ks, j + js, i + is, n) / hv;
   }
 
-  pvpe YAKL_INLINE compute_PVPE(const real5d v, const real5d w,
-                                const real5d dens, const real5d coriolisxz,
+  pvpe YAKL_INLINE compute_PVPE(const real5d &v, const real5d &w,
+                                const real5d &dens, const real5d &coriolisxz,
                                 int is, int js, int ks, int i, int j, int k,
                                 int n) const {
     pvpe vals;
@@ -359,10 +362,10 @@ public:
     return vals;
   }
 
-  pvpe YAKL_INLINE compute_PVPE_top(const real5d v, const real5d w,
-                                    const real5d dens, const real5d coriolisxz,
-                                    int is, int js, int ks, int i, int j, int k,
-                                    int n) const {
+  pvpe YAKL_INLINE compute_PVPE_top(const real5d &v, const real5d &w,
+                                    const real5d &dens,
+                                    const real5d &coriolisxz, int is, int js,
+                                    int ks, int i, int j, int k, int n) const {
     pvpe vals;
     // No subtraction here since this is called on primal cells p11
     real eta = compute_etaxz(v, w, coriolisxz, is, js, ks, i, j, k, n);
@@ -373,9 +376,9 @@ public:
     return vals;
   }
 
-  pvpe YAKL_INLINE compute_PVPE_bottom(const real5d v, const real5d w,
-                                       const real5d dens,
-                                       const real5d coriolisxz, int is, int js,
+  pvpe YAKL_INLINE compute_PVPE_bottom(const real5d &v, const real5d &w,
+                                       const real5d &dens,
+                                       const real5d &coriolisxz, int is, int js,
                                        int ks, int i, int j, int k,
                                        int n) const {
     pvpe vals;

--- a/dynamics/spam/src/hamiltonians/kinetic_energy.h
+++ b/dynamics/spam/src/hamiltonians/kinetic_energy.h
@@ -25,8 +25,8 @@
 //   this->is_initialized = true;
 // }
 //
-// real YAKL_INLINE compute_KE(const real5d v, const real5d dens, const real5d
-// densfct, int is, int js, int ks, int i, int j, int k)
+// real YAKL_INLINE compute_KE(const real5d& v, const real5d& dens, const
+// real5d& densfct, int is, int js, int ks, int i, int j, int k)
 // {
 //
 //   real KE, PE, IE;
@@ -55,9 +55,9 @@
 // }
 //
 //
-//  void YAKL_INLINE compute_dKdv(real5d F, real5d K, real5d HE, const real5d v,
-//  const real5d U, const real5d dens0, const real5d densfct0, int is, int js,
-//  int ks, int i, int j, int k)
+//  void YAKL_INLINE compute_dKdv(const real5d& F, const real5d& K, const
+//  real5d& HE, const real5d& v, const real5d& U, const real5d& dens0, const
+//  real5d& densfct0, int is, int js, int ks, int i, int j, int k)
 // {
 //   SArray<real,1,2> D0;
 //   SArray<real,1> he;
@@ -79,8 +79,8 @@
 // }
 //
 // // Note that this ADDS to Bvar...
-// void YAKL_INLINE compute_dKddens(real5d B, real5d Bfct, const real5d K, int
-// is, int js, int ks, int i, int j, int k)
+// void YAKL_INLINE compute_dKddens(const real5d& B, const real5d& Bfct, const
+// real5d& K, int is, int js, int ks, int i, int j, int k)
 // {
 //   SArray<real,1> K0;
 //   compute_I<1, diff_ord>(K0, K, *this->primal_geometry, *this->dual_geometry,
@@ -108,8 +108,9 @@ public:
     this->varset = variableset;
   }
 
-  real YAKL_INLINE compute_KE(const real5d v, const real5d dens, int is, int js,
-                              int ks, int i, int j, int k, int n) const {
+  real YAKL_INLINE compute_KE(const real5d &v, const real5d &dens, int is,
+                              int js, int ks, int i, int j, int k,
+                              int n) const {
 
     real KE;
     SArray<real, 1, 1> h0, h0im1, h0jm1, h0km1;
@@ -161,9 +162,10 @@ public:
   // FIX THIS TO GET TOTAL DENSITY FROM VARSET!
 
   template <ADD_MODE addmode = ADD_MODE::REPLACE>
-  void YAKL_INLINE compute_F_and_K(real5d F, real5d K, const real5d v,
-                                   const real5d U, const real5d dens0, int is,
-                                   int js, int ks, int i, int j, int k, int n,
+  void YAKL_INLINE compute_F_and_K(const real5d &F, const real5d &K,
+                                   const real5d &v, const real5d &U,
+                                   const real5d &dens0, int is, int js, int ks,
+                                   int i, int j, int k, int n,
                                    real fac = 1._fp) const {
     SArray<real, 2, ndims, 2> D0;
     SArray<real, 1, ndims> he;
@@ -201,9 +203,10 @@ public:
     K(0, k + ks, j + js, i + is, n) *= 0.5_fp;
   }
 
-  void YAKL_INLINE compute_F_and_he(real5d F, real5d HE, const real5d U,
-                                    const real5d dens0, int is, int js, int ks,
-                                    int i, int j, int k, int n) const {
+  void YAKL_INLINE compute_F_and_he(const real5d &F, const real5d &HE,
+                                    const real5d &U, const real5d &dens0,
+                                    int is, int js, int ks, int i, int j, int k,
+                                    int n) const {
     SArray<real, 2, ndims, 2> D0;
     SArray<real, 1, ndims> he;
 
@@ -233,8 +236,8 @@ public:
 
   // FIX THIS TO GET TOTAL DENSITY FROM VARSET!
   //  Note that this ADDS to Bvar...
-  void YAKL_INLINE compute_dKddens(real5d B, const real5d K, int is, int js,
-                                   int ks, int i, int j, int k, int n,
+  void YAKL_INLINE compute_dKddens(const real5d &B, const real5d &K, int is,
+                                   int js, int ks, int i, int j, int k, int n,
                                    real fac = 1._fp) const {
     SArray<real, 1, 1> K0;
     compute_I<1, diff_ord>(K0, K, this->primal_geometry, this->dual_geometry,
@@ -263,8 +266,8 @@ public:
 //    this->is_initialized = true;
 //  }
 //
-//  real YAKL_INLINE compute_KE(const real5d v, const real5d dens, const real5d
-//  densfct, int is, int js, int ks, int i, int j, int k, int n)
+//  real YAKL_INLINE compute_KE(const real5d& v, const real5d& dens, const
+//  real5d& densfct, int is, int js, int ks, int i, int j, int k, int n)
 //  {
 //
 //
@@ -326,9 +329,9 @@ public:
 //  }
 //
 //
-//   void YAKL_INLINE compute_dKdv(real5d F, real5d K, real5d HE, const real5d
-//   v, const real5d U, const real5d dens0, const real5d densfct0, int is, int
-//   js, int ks, int i, int j, int k, int n)
+//   void YAKL_INLINE compute_dKdv(const real5d& F, const real5d& K, const
+//   real5d& HE, const real5d& v, const real5d& U, const real5d& dens0, const
+//   real5d& densfct0, int is, int js, int ks, int i, int j, int k, int n)
 //  {
 //
 //    SArray<real,2,ndims,2> D0;
@@ -377,8 +380,8 @@ public:
 //  }
 //
 //  // Note that this ADDS to Bvar/Bfctvar...
-//  void YAKL_INLINE compute_dKddens(real5d B, real5d Bfct, const real5d K, int
-//  is, int js, int ks, int i, int j, int k, int n)
+//  void YAKL_INLINE compute_dKddens(const real5d& B, const real5d& Bfct, const
+//  real5d& K, int is, int js, int ks, int i, int j, int k, int n)
 //  {
 //    SArray<real,1,1> K0;
 //    compute_I<1, diff_ord>(K0, K, *this->primal_geometry,
@@ -416,8 +419,8 @@ public:
     this->varset = variableset;
   }
 
-  real YAKL_INLINE compute_KE_top(const real5d v, const real5d w,
-                                  const real5d dens, int is, int js, int ks,
+  real YAKL_INLINE compute_KE_top(const real5d &v, const real5d &w,
+                                  const real5d &dens, int is, int js, int ks,
                                   int i, int j, int k, int n) const {
     real K2 = 0.;
     SArray<real, 1, 1> UW0;
@@ -430,8 +433,8 @@ public:
     return _compute_KE(K2, v, w, dens, is, js, ks, i, j, k, n);
   }
 
-  real YAKL_INLINE compute_KE_bottom(const real5d v, const real5d w,
-                                     const real5d dens, int is, int js, int ks,
+  real YAKL_INLINE compute_KE_bottom(const real5d &v, const real5d &w,
+                                     const real5d &dens, int is, int js, int ks,
                                      int i, int j, int k, int n) const {
     real K2 = 0.;
     SArray<real, 1, 1> UW1;
@@ -445,9 +448,9 @@ public:
     return _compute_KE(K2, v, w, dens, is, js, ks, i, j, k, n);
   }
 
-  real YAKL_INLINE compute_KE(const real5d v, const real5d w, const real5d dens,
-                              int is, int js, int ks, int i, int j, int k,
-                              int n) const {
+  real YAKL_INLINE compute_KE(const real5d &v, const real5d &w,
+                              const real5d &dens, int is, int js, int ks, int i,
+                              int j, int k, int n) const {
     real K2 = 0.;
     SArray<real, 1, 1> UW0, UW1;
     compute_Hv<1, vert_diff_ord>(UW0, w, this->primal_geometry,
@@ -463,9 +466,9 @@ public:
     return _compute_KE(K2, v, w, dens, is, js, ks, i, j, k, n);
   }
 
-  real YAKL_INLINE _compute_KE(real K2, const real5d v, const real5d w,
-                               const real5d dens, int is, int js, int ks, int i,
-                               int j, int k, int n) const {
+  real YAKL_INLINE _compute_KE(real K2, const real5d &v, const real5d &w,
+                               const real5d &dens, int is, int js, int ks,
+                               int i, int j, int k, int n) const {
     real v0, v1;
     SArray<real, 1, ndims> U0, U1;
     compute_Hext<1, diff_ord>(U0, v, this->primal_geometry, this->dual_geometry,
@@ -502,9 +505,10 @@ public:
 
   // FIX THIS TO GET TOTAL DENSITY FROM VARSET!
   template <ADD_MODE addmode = ADD_MODE::REPLACE>
-  void YAKL_INLINE compute_Fw(real5d FW, const real5d UW, const real5d dens0,
-                              int is, int js, int ks, int i, int j, int k,
-                              int n, real fac = 1._fp) const {
+  void YAKL_INLINE compute_Fw(const real5d &FW, const real5d &UW,
+                              const real5d &dens0, int is, int js, int ks,
+                              int i, int j, int k, int n,
+                              real fac = 1._fp) const {
     // SArray<real,2> Dv;
     // compute hew = phiw * h0
     // Dv(0) = dens0(0, k+ks, j+js, i+is);
@@ -527,9 +531,9 @@ public:
 
   // version that takes a reference state
   template <ADD_MODE addmode = ADD_MODE::REPLACE>
-  void YAKL_INLINE compute_Fw(real5d FW, const real5d UW, const real3d dens0,
-                              int is, int js, int ks, int i, int j, int k,
-                              int n, real fac = 1._fp) const {
+  void YAKL_INLINE compute_Fw(const real5d &FW, const real5d &UW,
+                              const real3d dens0, int is, int js, int ks, int i,
+                              int j, int k, int n, real fac = 1._fp) const {
     real hew = dens0(0, k, n);
     if (addmode == ADD_MODE::REPLACE) {
       FW(0, k + ks, j + js, i + is, n) =
@@ -540,9 +544,10 @@ public:
     }
   }
 
-  void YAKL_INLINE compute_Fw_and_he(real5d FW, real5d HEw, const real5d UW,
-                                     const real5d dens0, int is, int js, int ks,
-                                     int i, int j, int k, int n) const {
+  void YAKL_INLINE compute_Fw_and_he(const real5d &FW, const real5d &HEw,
+                                     const real5d &UW, const real5d &dens0,
+                                     int is, int js, int ks, int i, int j,
+                                     int k, int n) const {
     // SArray<real,2> Dv;
     // compute hew = phiw * h0
     // Dv(0) = dens0(0, k+ks, j+js, i+is);
@@ -558,8 +563,9 @@ public:
     // HEw(0,k+ks,j+js,i+is) << "\n" << std::flush;
   }
 
-  void YAKL_INLINE compute_hew(real5d HEw, const real5d dens0, int is, int js,
-                               int ks, int i, int j, int k, int n) const {
+  void YAKL_INLINE compute_hew(const real5d &HEw, const real5d &dens0, int is,
+                               int js, int ks, int i, int j, int k,
+                               int n) const {
     // SArray<real,2> Dv;
     // compute hew = phiw * h0
     // Dv(0) = dens0(0, k+ks, j+js, i+is);
@@ -572,8 +578,8 @@ public:
     HEw(0, k + ks, j + js, i + is, n) = hew;
   }
 
-  void YAKL_INLINE compute_K(real5d K, const real5d v, const real5d U,
-                             const real5d w, const real5d UW, int is, int js,
+  void YAKL_INLINE compute_K(const real5d &K, const real5d &v, const real5d &U,
+                             const real5d &w, const real5d &UW, int is, int js,
                              int ks, int i, int j, int k, int n) const {
     // compute K = 1/2 * PhiT(U,V) + 1/2 * PhiTW(UW,W)
     real K2 = 0.;
@@ -610,9 +616,9 @@ public:
 
   // FIX THIS TO GET TOTAL DENSITY FROM VARSET!
   template <ADD_MODE addmode = ADD_MODE::REPLACE>
-  void YAKL_INLINE compute_F(real5d F, const real5d U, const real5d dens0,
-                             int is, int js, int ks, int i, int j, int k, int n,
-                             real fac = 1._fp) const {
+  void YAKL_INLINE compute_F(const real5d &F, const real5d &U,
+                             const real5d &dens0, int is, int js, int ks, int i,
+                             int j, int k, int n, real fac = 1._fp) const {
     SArray<real, 2, ndims, 2> D0;
     SArray<real, 1, ndims> he;
 
@@ -644,9 +650,9 @@ public:
 
   // version that takes a reference state
   template <ADD_MODE addmode = ADD_MODE::REPLACE>
-  void YAKL_INLINE compute_F(real5d F, const real5d U, const real3d dens0,
-                             int is, int js, int ks, int i, int j, int k, int n,
-                             real fac = 1._fp) const {
+  void YAKL_INLINE compute_F(const real5d &F, const real5d &U,
+                             const real3d dens0, int is, int js, int ks, int i,
+                             int j, int k, int n, real fac = 1._fp) const {
     SArray<real, 2, ndims, 2> D0;
     real he = dens0(0, k, n);
 
@@ -662,8 +668,9 @@ public:
     }
   }
 
-  void YAKL_INLINE compute_he(real5d HE, const real5d dens0, int is, int js,
-                              int ks, int i, int j, int k, int n) const {
+  void YAKL_INLINE compute_he(const real5d &HE, const real5d &dens0, int is,
+                              int js, int ks, int i, int j, int k,
+                              int n) const {
     SArray<real, 2, ndims, 2> D0;
     SArray<real, 1, ndims> he;
 
@@ -684,9 +691,10 @@ public:
     }
   }
 
-  void YAKL_INLINE compute_F_and_he(real5d F, real5d HE, const real5d U,
-                                    const real5d dens0, int is, int js, int ks,
-                                    int i, int j, int k, int n) const {
+  void YAKL_INLINE compute_F_and_he(const real5d &F, const real5d &HE,
+                                    const real5d &U, const real5d &dens0,
+                                    int is, int js, int ks, int i, int j, int k,
+                                    int n) const {
     SArray<real, 2, ndims, 2> D0;
     SArray<real, 1, ndims> he;
 
@@ -713,8 +721,8 @@ public:
 
   // FIX THIS TO GET TOTAL DENSITY FROM VARSET!
   template <ADD_MODE addmode = ADD_MODE::REPLACE>
-  void YAKL_INLINE compute_dKddens(real5d B, const real5d K, int is, int js,
-                                   int ks, int i, int j, int k, int n,
+  void YAKL_INLINE compute_dKddens(const real5d &B, const real5d &K, int is,
+                                   int js, int ks, int i, int j, int k, int n,
                                    real fac = 1._fp) const {
     SArray<real, 1, 1> K0;
     compute_Iext<1, diff_ord, vert_diff_ord>(K0, K, this->primal_geometry,

--- a/dynamics/spam/src/hamiltonians/layer_models.h
+++ b/dynamics/spam/src/hamiltonians/layer_models.h
@@ -22,7 +22,7 @@ public:
 
   void set_parameters(real gin) { this->g = gin; }
 
-  real YAKL_INLINE compute_PE(const real5d dens, const real5d hs, int is,
+  real YAKL_INLINE compute_PE(const real5d &dens, const real5d &hs, int is,
                               int js, int ks, int i, int j, int k,
                               int n) const {
     // Assumes things are stored in dens as as 0=h, 1=S, active tracers,
@@ -45,7 +45,7 @@ public:
     return PE;
   }
 
-  real YAKL_INLINE compute_IE(const real5d dens, int is, int js, int ks, int i,
+  real YAKL_INLINE compute_IE(const real5d &dens, int is, int js, int ks, int i,
                               int j, int k, int n) const {
     return 0;
   }
@@ -60,9 +60,10 @@ public:
   // So it is ok for a bit
 
   template <ADD_MODE addmode = ADD_MODE::REPLACE>
-  void YAKL_INLINE compute_dHsdx(real5d B, const real5d dens, const real5d hs,
-                                 int is, int js, int ks, int i, int j, int k,
-                                 int n, real fac = 1._fp) const {
+  void YAKL_INLINE compute_dHsdx(const real5d &B, const real5d &dens,
+                                 const real5d &hs, int is, int js, int ks,
+                                 int i, int j, int k, int n,
+                                 real fac = 1._fp) const {
 
     // Assumes things are stored in dens as as 0=h, 1=S, active tracers,
     // inactive tracers
@@ -139,7 +140,7 @@ public:
 
   void set_parameters(real gin) { this->g = gin; }
 
-  real YAKL_INLINE compute_PE(const real5d dens, const real5d hs, int is,
+  real YAKL_INLINE compute_PE(const real5d &dens, const real5d &hs, int is,
                               int js, int ks, int i, int j, int k,
                               int n) const {
     // Assumes things are stored in dens as as 0=h, active tracers, inactive
@@ -166,15 +167,16 @@ public:
     return PE;
   }
 
-  real YAKL_INLINE compute_IE(const real5d dens, int is, int js, int ks, int i,
+  real YAKL_INLINE compute_IE(const real5d &dens, int is, int js, int ks, int i,
                               int j, int k, int n) const {
     return 0;
   }
 
   template <ADD_MODE addmode = ADD_MODE::REPLACE>
-  void YAKL_INLINE compute_dHsdx(real5d B, const real5d dens, const real5d hs,
-                                 int is, int js, int ks, int i, int j, int k,
-                                 int n, real fac = 1._fp) const {
+  void YAKL_INLINE compute_dHsdx(const real5d &B, const real5d &dens,
+                                 const real5d &hs, int is, int js, int ks,
+                                 int i, int j, int k, int n,
+                                 real fac = 1._fp) const {
     // Assumes things are stored in dens as as 0=h, active tracers, inactive
     // tracers
 

--- a/dynamics/spam/src/hamiltonians/variableset.h
+++ b/dynamics/spam/src/hamiltonians/variableset.h
@@ -130,29 +130,30 @@ public:
     yakl::fence();
   }
 
-  real YAKL_INLINE get_total_density(const real5d densvar, int k, int j, int i,
+  real YAKL_INLINE get_total_density(const real5d &densvar, int k, int j, int i,
                                      int ks, int js, int is, int n) const {};
-  real YAKL_INLINE get_dry_density(const real5d densvar, int k, int j, int i,
+  real YAKL_INLINE get_dry_density(const real5d &densvar, int k, int j, int i,
                                    int ks, int js, int is, int n) const {};
-  real YAKL_INLINE get_entropic_var(const real5d densvar, int k, int j, int i,
+  real YAKL_INLINE get_entropic_var(const real5d &densvar, int k, int j, int i,
                                     int ks, int js, int is, int n) const {};
-  void YAKL_INLINE set_density(real dens, real dry_dens, real5d densvar, int k,
-                               int j, int i, int ks, int js, int is,
+  void YAKL_INLINE set_density(real dens, real dry_dens, const real5d &densvar,
+                               int k, int j, int i, int ks, int js, int is,
                                int n) const {};
   void YAKL_INLINE set_entropic_density(real entropic_var_density,
-                                        real5d densvar, int k, int j, int i,
-                                        int ks, int js, int is, int n) const {};
-  real YAKL_INLINE get_alpha(const real5d densvar, int k, int j, int i, int ks,
+                                        const real5d &densvar, int k, int j,
+                                        int i, int ks, int js, int is,
+                                        int n) const {};
+  real YAKL_INLINE get_alpha(const real5d &densvar, int k, int j, int i, int ks,
                              int js, int is, int n) const {};
-  real YAKL_INLINE get_qd(const real5d densvar, int k, int j, int i, int ks,
+  real YAKL_INLINE get_qd(const real5d &densvar, int k, int j, int i, int ks,
                           int js, int is, int n) const {};
-  real YAKL_INLINE get_qv(const real5d densvar, int k, int j, int i, int ks,
+  real YAKL_INLINE get_qv(const real5d &densvar, int k, int j, int i, int ks,
                           int js, int is, int n) const {};
-  real YAKL_INLINE get_ql(const real5d densvar, int k, int j, int i, int ks,
+  real YAKL_INLINE get_ql(const real5d &densvar, int k, int j, int i, int ks,
                           int js, int is, int n) const {};
-  real YAKL_INLINE get_qi(const real5d densvar, int k, int j, int i, int ks,
+  real YAKL_INLINE get_qi(const real5d &densvar, int k, int j, int i, int ks,
                           int js, int is, int n) const {};
-  real YAKL_INLINE _water_dens(const real5d densvar, int k, int j, int i,
+  real YAKL_INLINE _water_dens(const real5d &densvar, int k, int j, int i,
                                int ks, int js, int is, int n) const {};
 
   void convert_dynamics_to_coupler_state(PamCoupler &coupler,
@@ -440,7 +441,7 @@ void VariableSetBase<VS_CE>::initialize(PamCoupler &coupler,
 }
 
 template <>
-real YAKL_INLINE VariableSetBase<VS_CE>::get_entropic_var(const real5d densvar,
+real YAKL_INLINE VariableSetBase<VS_CE>::get_entropic_var(const real5d &densvar,
                                                           int k, int j, int i,
                                                           int ks, int js,
                                                           int is, int n) const {
@@ -448,7 +449,7 @@ real YAKL_INLINE VariableSetBase<VS_CE>::get_entropic_var(const real5d densvar,
          densvar(0, k + ks, j + js, i + is, n);
 }
 template <>
-real YAKL_INLINE VariableSetBase<VS_CE>::get_alpha(const real5d densvar, int k,
+real YAKL_INLINE VariableSetBase<VS_CE>::get_alpha(const real5d &densvar, int k,
                                                    int j, int i, int ks, int js,
                                                    int is, int n) const {
   return dual_geometry.get_area_11entity(k + ks, j + js, i + is) /
@@ -475,21 +476,21 @@ void VariableSetBase<VS_MCE_rho>::initialize(
 
 template <>
 real YAKL_INLINE VariableSetBase<VS_MCE_rho>::get_total_density(
-    const real5d densvar, int k, int j, int i, int ks, int js, int is,
+    const real5d &densvar, int k, int j, int i, int ks, int js, int is,
     int n) const {
   return densvar(0, k + ks, j + js, i + is, n);
 }
 
 template <>
 real YAKL_INLINE VariableSetBase<VS_MCE_rho>::get_entropic_var(
-    const real5d densvar, int k, int j, int i, int ks, int js, int is,
+    const real5d &densvar, int k, int j, int i, int ks, int js, int is,
     int n) const {
   return densvar(1, k + ks, j + js, i + is, n) /
          densvar(0, k + ks, j + js, i + is, n);
 }
 
 template <>
-real YAKL_INLINE VariableSetBase<VS_MCE_rho>::get_alpha(const real5d densvar,
+real YAKL_INLINE VariableSetBase<VS_MCE_rho>::get_alpha(const real5d &densvar,
                                                         int k, int j, int i,
                                                         int ks, int js, int is,
                                                         int n) const {
@@ -498,7 +499,7 @@ real YAKL_INLINE VariableSetBase<VS_MCE_rho>::get_alpha(const real5d densvar,
 }
 
 template <>
-real YAKL_INLINE VariableSetBase<VS_MCE_rho>::get_qv(const real5d densvar,
+real YAKL_INLINE VariableSetBase<VS_MCE_rho>::get_qv(const real5d &densvar,
                                                      int k, int j, int i,
                                                      int ks, int js, int is,
                                                      int n) const {
@@ -506,7 +507,7 @@ real YAKL_INLINE VariableSetBase<VS_MCE_rho>::get_qv(const real5d densvar,
          densvar(0, k + ks, j + js, i + is, n);
 }
 template <>
-real YAKL_INLINE VariableSetBase<VS_MCE_rho>::get_ql(const real5d densvar,
+real YAKL_INLINE VariableSetBase<VS_MCE_rho>::get_ql(const real5d &densvar,
                                                      int k, int j, int i,
                                                      int ks, int js, int is,
                                                      int n) const {
@@ -514,7 +515,7 @@ real YAKL_INLINE VariableSetBase<VS_MCE_rho>::get_ql(const real5d densvar,
          densvar(0, k + ks, j + js, i + is, n);
 }
 template <>
-real YAKL_INLINE VariableSetBase<VS_MCE_rho>::get_qi(const real5d densvar,
+real YAKL_INLINE VariableSetBase<VS_MCE_rho>::get_qi(const real5d &densvar,
                                                      int k, int j, int i,
                                                      int ks, int js, int is,
                                                      int n) const {
@@ -523,7 +524,7 @@ real YAKL_INLINE VariableSetBase<VS_MCE_rho>::get_qi(const real5d densvar,
 }
 
 template <>
-real YAKL_INLINE VariableSetBase<VS_MCE_rho>::_water_dens(const real5d densvar,
+real YAKL_INLINE VariableSetBase<VS_MCE_rho>::_water_dens(const real5d &densvar,
                                                           int k, int j, int i,
                                                           int ks, int js,
                                                           int is, int n) const {
@@ -544,13 +545,13 @@ real YAKL_INLINE VariableSetBase<VS_MCE_rho>::_water_dens(const real5d densvar,
 
 template <>
 real YAKL_INLINE VariableSetBase<VS_MCE_rho>::get_dry_density(
-    const real5d densvar, int k, int j, int i, int ks, int js, int is,
+    const real5d &densvar, int k, int j, int i, int ks, int js, int is,
     int n) const {
   return (densvar(0, k + ks, j + js, i + is, n) -
           _water_dens(densvar, k, j, i, ks, js, is, n));
 }
 template <>
-real YAKL_INLINE VariableSetBase<VS_MCE_rho>::get_qd(const real5d densvar,
+real YAKL_INLINE VariableSetBase<VS_MCE_rho>::get_qd(const real5d &densvar,
                                                      int k, int j, int i,
                                                      int ks, int js, int is,
                                                      int n) const {
@@ -561,14 +562,14 @@ real YAKL_INLINE VariableSetBase<VS_MCE_rho>::get_qd(const real5d densvar,
 
 template <>
 void YAKL_INLINE VariableSetBase<VS_MCE_rho>::set_density(
-    real dens, real dryden, real5d densvar, int k, int j, int i, int ks, int js,
-    int is, int n) const {
+    real dens, real dryden, const real5d &densvar, int k, int j, int i, int ks,
+    int js, int is, int n) const {
   densvar(0, k + ks, j + js, i + is, n) = dens;
 }
 template <>
 void YAKL_INLINE VariableSetBase<VS_MCE_rho>::set_entropic_density(
-    real entropic_var_density, real5d densvar, int k, int j, int i, int ks,
-    int js, int is, int n) const {
+    real entropic_var_density, const real5d &densvar, int k, int j, int i,
+    int ks, int js, int is, int n) const {
   densvar(1, k + ks, j + js, i + is, n) = entropic_var_density;
 }
 
@@ -589,7 +590,7 @@ void VariableSetBase<VS_MCE_rhod>::initialize(
 
 template <>
 real YAKL_INLINE VariableSetBase<VS_MCE_rhod>::get_total_density(
-    const real5d densvar, int k, int j, int i, int ks, int js, int is,
+    const real5d &densvar, int k, int j, int i, int ks, int js, int is,
     int n) const {
   real dry_dens = densvar(0, k + ks, j + js, i + is, n);
   real vap_dens =
@@ -609,20 +610,20 @@ real YAKL_INLINE VariableSetBase<VS_MCE_rhod>::get_total_density(
 
 template <>
 real YAKL_INLINE VariableSetBase<VS_MCE_rhod>::get_dry_density(
-    const real5d densvar, int k, int j, int i, int ks, int js, int is,
+    const real5d &densvar, int k, int j, int i, int ks, int js, int is,
     int n) const {
   return densvar(0, k + ks, j + js, i + is, n);
 }
 template <>
 real YAKL_INLINE VariableSetBase<VS_MCE_rhod>::get_entropic_var(
-    const real5d densvar, int k, int j, int i, int ks, int js, int is,
+    const real5d &densvar, int k, int j, int i, int ks, int js, int is,
     int n) const {
   return densvar(1, k + ks, j + js, i + is, n) /
          get_total_density(densvar, k, j, i, ks, js, is, n);
 }
 
 template <>
-real YAKL_INLINE VariableSetBase<VS_MCE_rhod>::get_alpha(const real5d densvar,
+real YAKL_INLINE VariableSetBase<VS_MCE_rhod>::get_alpha(const real5d &densvar,
                                                          int k, int j, int i,
                                                          int ks, int js, int is,
                                                          int n) const {
@@ -630,7 +631,7 @@ real YAKL_INLINE VariableSetBase<VS_MCE_rhod>::get_alpha(const real5d densvar,
          get_total_density(densvar, k, j, i, ks, js, is, n);
 }
 template <>
-real YAKL_INLINE VariableSetBase<VS_MCE_rhod>::get_qd(const real5d densvar,
+real YAKL_INLINE VariableSetBase<VS_MCE_rhod>::get_qd(const real5d &densvar,
                                                       int k, int j, int i,
                                                       int ks, int js, int is,
                                                       int n) const {
@@ -639,7 +640,7 @@ real YAKL_INLINE VariableSetBase<VS_MCE_rhod>::get_qd(const real5d densvar,
 }
 
 template <>
-real YAKL_INLINE VariableSetBase<VS_MCE_rhod>::get_qv(const real5d densvar,
+real YAKL_INLINE VariableSetBase<VS_MCE_rhod>::get_qv(const real5d &densvar,
                                                       int k, int j, int i,
                                                       int ks, int js, int is,
                                                       int n) const {
@@ -647,7 +648,7 @@ real YAKL_INLINE VariableSetBase<VS_MCE_rhod>::get_qv(const real5d densvar,
          get_total_density(densvar, k, j, i, ks, js, is, n);
 }
 template <>
-real YAKL_INLINE VariableSetBase<VS_MCE_rhod>::get_ql(const real5d densvar,
+real YAKL_INLINE VariableSetBase<VS_MCE_rhod>::get_ql(const real5d &densvar,
                                                       int k, int j, int i,
                                                       int ks, int js, int is,
                                                       int n) const {
@@ -655,7 +656,7 @@ real YAKL_INLINE VariableSetBase<VS_MCE_rhod>::get_ql(const real5d densvar,
          get_total_density(densvar, k, j, i, ks, js, is, n);
 }
 template <>
-real YAKL_INLINE VariableSetBase<VS_MCE_rhod>::get_qi(const real5d densvar,
+real YAKL_INLINE VariableSetBase<VS_MCE_rhod>::get_qi(const real5d &densvar,
                                                       int k, int j, int i,
                                                       int ks, int js, int is,
                                                       int n) const {
@@ -664,14 +665,14 @@ real YAKL_INLINE VariableSetBase<VS_MCE_rhod>::get_qi(const real5d densvar,
 }
 template <>
 void YAKL_INLINE VariableSetBase<VS_MCE_rhod>::set_density(
-    real dens, real drydens, real5d densvar, int k, int j, int i, int ks,
+    real dens, real drydens, const real5d &densvar, int k, int j, int i, int ks,
     int js, int is, int n) const {
   densvar(0, k + ks, j + js, i + is, n) = drydens;
 }
 template <>
 void YAKL_INLINE VariableSetBase<VS_MCE_rhod>::set_entropic_density(
-    real entropic_var_density, real5d densvar, int k, int j, int i, int ks,
-    int js, int is, int n) const {
+    real entropic_var_density, const real5d &densvar, int k, int j, int i,
+    int ks, int js, int is, int n) const {
   densvar(1, k + ks, j + js, i + is, n) = entropic_var_density;
 }
 

--- a/dynamics/spam/src/operators/ext_deriv.h
+++ b/dynamics/spam/src/operators/ext_deriv.h
@@ -15,8 +15,9 @@ void YAKL_INLINE cwDbar2(SArray<real, 1, ndofs> &var, real c,
 }
 
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-YAKL_INLINE void compute_cwDbar2(real5d tendvar, real c, const real5d U, int is,
-                                 int js, int ks, int i, int j, int k, int n) {
+YAKL_INLINE void compute_cwDbar2(const real5d &tendvar, real c, const real5d &U,
+                                 int is, int js, int ks, int i, int j, int k,
+                                 int n) {
   SArray<real, 1, ndofs> tend;
   SArray<real, 3, ndofs, ndims, 2> recon;
   SArray<real, 2, ndims, 2> flux;
@@ -98,8 +99,8 @@ void YAKL_INLINE wDbar2(SArray<real, 1, ndofs> &var,
 }
 
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-YAKL_INLINE void compute_wDbar2(real5d tendvar, const real5d reconvar,
-                                const real5d U, int is, int js, int ks, int i,
+YAKL_INLINE void compute_wDbar2(const real5d &tendvar, const real5d &reconvar,
+                                const real5d &U, int is, int js, int ks, int i,
                                 int j, int k, int n) {
   SArray<real, 1, ndofs> tend;
   SArray<real, 3, ndofs, ndims, 2> recon;
@@ -142,8 +143,8 @@ YAKL_INLINE void compute_wDbar2(real5d tendvar, const real5d reconvar,
 
 // version that take a reference state
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-YAKL_INLINE void compute_wDbar2(real5d tendvar, const real3d reconvar,
-                                const real5d U, int is, int js, int ks, int i,
+YAKL_INLINE void compute_wDbar2(const real5d &tendvar, const real3d &reconvar,
+                                const real5d &U, int is, int js, int ks, int i,
                                 int j, int k, int n) {
   SArray<real, 1, ndofs> tend;
   SArray<real, 3, ndofs, ndims, 2> recon;
@@ -182,10 +183,10 @@ YAKL_INLINE void compute_wDbar2(real5d tendvar, const real3d reconvar,
 }
 
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-YAKL_INLINE void compute_wDbar2_fct(real5d tendvar, const real5d reconvar,
-                                    const real5d phivar, const real5d U, int is,
-                                    int js, int ks, int i, int j, int k,
-                                    int n) {
+YAKL_INLINE void
+compute_wDbar2_fct(const real5d &tendvar, const real5d &reconvar,
+                   const real5d &phivar, const real5d &U, int is, int js,
+                   int ks, int i, int j, int k, int n) {
   SArray<real, 1, ndofs> tend;
   SArray<real, 3, ndofs, ndims, 2> recon;
   SArray<real, 2, ndims, 2> flux;
@@ -240,10 +241,10 @@ void YAKL_INLINE wDvbar(SArray<real, 1, ndofs> &var,
 }
 
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-YAKL_INLINE void compute_wDvbar_fct(real5d tendvar, const real5d vertreconvar,
-                                    const real5d vertphivar, const real5d UW,
-                                    int is, int js, int ks, int i, int j, int k,
-                                    int n) {
+YAKL_INLINE void
+compute_wDvbar_fct(const real5d &tendvar, const real5d &vertreconvar,
+                   const real5d &vertphivar, const real5d &UW, int is, int js,
+                   int ks, int i, int j, int k, int n) {
   SArray<real, 1, ndofs> tend;
   SArray<real, 2, ndofs, 2> recon;
   SArray<real, 1, 2> flux;
@@ -270,9 +271,10 @@ YAKL_INLINE void compute_wDvbar_fct(real5d tendvar, const real5d vertreconvar,
 }
 
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-YAKL_INLINE void compute_wDvbar(real5d tendvar, const real5d vertreconvar,
-                                const real5d UW, int is, int js, int ks, int i,
-                                int j, int k, int n) {
+YAKL_INLINE void compute_wDvbar(const real5d &tendvar,
+                                const real5d &vertreconvar, const real5d &UW,
+                                int is, int js, int ks, int i, int j, int k,
+                                int n) {
   SArray<real, 1, ndofs> tend;
   SArray<real, 2, ndofs, 2> recon;
   SArray<real, 1, 2> flux;
@@ -299,9 +301,10 @@ YAKL_INLINE void compute_wDvbar(real5d tendvar, const real5d vertreconvar,
 
 // version that take a reference state
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-YAKL_INLINE void compute_wDvbar(real5d tendvar, const real3d vertreconvar,
-                                const real5d UW, int is, int js, int ks, int i,
-                                int j, int k, int n) {
+YAKL_INLINE void compute_wDvbar(const real5d &tendvar,
+                                const real3d &vertreconvar, const real5d &UW,
+                                int is, int js, int ks, int i, int j, int k,
+                                int n) {
   SArray<real, 1, ndofs> tend;
   SArray<real, 2, ndofs, 2> recon;
   SArray<real, 1, 2> flux;
@@ -356,8 +359,8 @@ void YAKL_INLINE fourier_cwD1(const SArray<complex, 1, ndims> &D1hat,
 }
 
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-void YAKL_INLINE compute_cwD1(real5d tendvar, SArray<real, 1, ndofs> &c,
-                              const real5d densvar, int is, int js, int ks,
+void YAKL_INLINE compute_cwD1(const real5d &tendvar, SArray<real, 1, ndofs> &c,
+                              const real5d &densvar, int is, int js, int ks,
                               int i, int j, int k, int n) {
   SArray<real, 1, ndims> tend;
   SArray<real, 2, ndofs, ndims> recon;
@@ -399,8 +402,8 @@ void YAKL_INLINE wD1(SArray<real, 1, ndims> &var,
 }
 
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-void YAKL_INLINE compute_wD1(real5d tendvar, const real5d reconvar,
-                             const real5d densvar, int is, int js, int ks,
+void YAKL_INLINE compute_wD1(const real5d &tendvar, const real5d &reconvar,
+                             const real5d &densvar, int is, int js, int ks,
                              int i, int j, int k, int n) {
   SArray<real, 1, ndims> tend;
   SArray<real, 2, ndofs, ndims> recon;
@@ -431,8 +434,8 @@ void YAKL_INLINE compute_wD1(real5d tendvar, const real5d reconvar,
 
 // version that takes a reference state
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-void YAKL_INLINE compute_wD1(real5d tendvar, const real3d reconvar,
-                             const real5d densvar, int is, int js, int ks,
+void YAKL_INLINE compute_wD1(const real5d &tendvar, const real3d &reconvar,
+                             const real5d &densvar, int is, int js, int ks,
                              int i, int j, int k, int n) {
   SArray<real, 1, ndims> tend;
   SArray<real, 2, ndofs, ndims> recon;
@@ -462,8 +465,8 @@ void YAKL_INLINE compute_wD1(real5d tendvar, const real3d reconvar,
 }
 
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-void YAKL_INLINE compute_wD1_fct(real5d tendvar, const real5d reconvar,
-                                 const real5d Phivar, const real5d densvar,
+void YAKL_INLINE compute_wD1_fct(const real5d &tendvar, const real5d &reconvar,
+                                 const real5d &Phivar, const real5d &densvar,
                                  int is, int js, int ks, int i, int j, int k,
                                  int n) {
   SArray<real, 1, ndims> tend;
@@ -505,10 +508,11 @@ void YAKL_INLINE wDv(real &var, SArray<real, 1, ndofs> const &recon,
 }
 
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-void YAKL_INLINE compute_wDv_fct(real5d tendvar, const real5d vertreconvar,
-                                 const real5d Phivertvar, const real5d densvar,
-                                 int is, int js, int ks, int i, int j, int k,
-                                 int n) {
+void YAKL_INLINE compute_wDv_fct(const real5d &tendvar,
+                                 const real5d &vertreconvar,
+                                 const real5d &Phivertvar,
+                                 const real5d &densvar, int is, int js, int ks,
+                                 int i, int j, int k, int n) {
   real tend;
   SArray<real, 1, ndofs> recon;
   SArray<real, 2, ndofs, 2> dens;
@@ -529,8 +533,8 @@ void YAKL_INLINE compute_wDv_fct(real5d tendvar, const real5d vertreconvar,
 }
 
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-void YAKL_INLINE compute_wDv(real5d tendvar, const real5d vertreconvar,
-                             const real5d densvar, int is, int js, int ks,
+void YAKL_INLINE compute_wDv(const real5d &tendvar, const real5d &vertreconvar,
+                             const real5d &densvar, int is, int js, int ks,
                              int i, int j, int k, int n) {
   real tend;
   SArray<real, 1, ndofs> recon;
@@ -552,8 +556,8 @@ void YAKL_INLINE compute_wDv(real5d tendvar, const real5d vertreconvar,
 
 // versiion that take a reference state
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-void YAKL_INLINE compute_wDv(real5d tendvar, const real3d vertreconvar,
-                             const real5d densvar, int is, int js, int ks,
+void YAKL_INLINE compute_wDv(const real5d &tendvar, const real3d &vertreconvar,
+                             const real5d &densvar, int is, int js, int ks,
                              int i, int j, int k, int n) {
   real tend;
   SArray<real, 1, ndofs> recon;
@@ -584,7 +588,7 @@ void YAKL_INLINE D2(SArray<real, 1, ndofs> &var,
 }
 
 template <uint ndofs>
-void YAKL_INLINE compute_D2(SArray<real, 1, ndofs> &tend, const real5d fluxvar,
+void YAKL_INLINE compute_D2(SArray<real, 1, ndofs> &tend, const real5d &fluxvar,
                             int is, int js, int ks, int i, int j, int k,
                             int n) {
   SArray<real, 2, ndofs, 4> flux;
@@ -600,8 +604,9 @@ void YAKL_INLINE compute_D2(SArray<real, 1, ndofs> &tend, const real5d fluxvar,
 }
 
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-void YAKL_INLINE compute_D2(real5d tendvar, const real5d fluxvar, int is,
-                            int js, int ks, int i, int j, int k, int n) {
+void YAKL_INLINE compute_D2(const real5d &tendvar, const real5d &fluxvar,
+                            int is, int js, int ks, int i, int j, int k,
+                            int n) {
   SArray<real, 1, ndofs> tend;
   compute_D2<ndofs>(tend, fluxvar, is, js, ks, i, j, k, n);
   if (addmode == ADD_MODE::REPLACE) {
@@ -617,8 +622,8 @@ void YAKL_INLINE compute_D2(real5d tendvar, const real5d fluxvar, int is,
 }
 
 template <uint ndofs>
-void YAKL_INLINE compute_Dxz(SArray<real, 1, ndofs> &tend, const real5d v,
-                             const real5d w, int is, int js, int ks, int i,
+void YAKL_INLINE compute_Dxz(SArray<real, 1, ndofs> &tend, const real5d &v,
+                             const real5d &w, int is, int js, int ks, int i,
                              int j, int k, int n) {
   SArray<real, 1, 4> flux;
   for (int l = 0; l < ndofs; l++) {
@@ -630,9 +635,9 @@ void YAKL_INLINE compute_Dxz(SArray<real, 1, ndofs> &tend, const real5d v,
   }
 }
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-void YAKL_INLINE compute_Dxz(real5d tendvar, const real5d v, const real5d w,
-                             int is, int js, int ks, int i, int j, int k,
-                             int n) {
+void YAKL_INLINE compute_Dxz(const real5d &tendvar, const real5d &v,
+                             const real5d &w, int is, int js, int ks, int i,
+                             int j, int k, int n) {
   SArray<real, 1, ndofs> tend;
   compute_Dxz<ndofs>(tend, v, w, is, js, ks, i, j, k, n);
   for (int l = 0; l < ndofs; l++) {

--- a/dynamics/spam/src/operators/fct.h
+++ b/dynamics/spam/src/operators/fct.h
@@ -14,9 +14,10 @@ void YAKL_INLINE calculate_edgeflux(SArray<real, 2, ndofs, ndims> &edgeflux,
 }
 
 template <uint ndofs>
-YAKL_INLINE void compute_edgefluxes(real5d edgefluxvar, const real5d reconvar,
-                                    const real5d U, int is, int js, int ks,
-                                    int i, int j, int k, int n) {
+YAKL_INLINE void compute_edgefluxes(const real5d &edgefluxvar,
+                                    const real5d &reconvar, const real5d &U,
+                                    int is, int js, int ks, int i, int j, int k,
+                                    int n) {
   SArray<real, 2, ndofs, ndims> edgeflux;
   SArray<real, 2, ndofs, ndims> recon;
   SArray<real, 1, ndims> flux;
@@ -45,10 +46,10 @@ void YAKL_INLINE calculate_vertedgeflux(SArray<real, 1, ndofs> &edgeflux,
 }
 
 template <uint ndofs>
-YAKL_INLINE void compute_vertedgefluxes(real5d vertedgefluxvar,
-                                        const real5d vertreconvar,
-                                        const real5d UW, int is, int js, int ks,
-                                        int i, int j, int k, int n) {
+YAKL_INLINE void compute_vertedgefluxes(const real5d &vertedgefluxvar,
+                                        const real5d &vertreconvar,
+                                        const real5d &UW, int is, int js,
+                                        int ks, int i, int j, int k, int n) {
   SArray<real, 1, ndofs> edgeflux;
   SArray<real, 1, ndofs> recon;
   real flux;
@@ -96,9 +97,9 @@ calculate_Mfext(SArray<real, 1, ndofs> &Mf,
 }
 
 template <uint ndofs>
-YAKL_INLINE void compute_Mf(real5d Mfvar, const real5d edgefluxvar, real dt,
-                            int is, int js, int ks, int i, int j, int k,
-                            int n) {
+YAKL_INLINE void compute_Mf(const real5d &Mfvar, const real5d &edgefluxvar,
+                            real dt, int is, int js, int ks, int i, int j,
+                            int k, int n) {
   SArray<real, 1, ndofs> Mf;
   SArray<real, 3, ndofs, ndims, 2> edgeflux;
   for (int l = 0; l < ndofs; l++) {
@@ -122,8 +123,8 @@ YAKL_INLINE void compute_Mf(real5d Mfvar, const real5d edgefluxvar, real dt,
 }
 
 template <uint ndofs>
-YAKL_INLINE void compute_Mfext(real5d Mfvar, const real5d edgefluxvar,
-                               const real5d vertedgefluxvar, real dt, int is,
+YAKL_INLINE void compute_Mfext(const real5d &Mfvar, const real5d &edgefluxvar,
+                               const real5d &vertedgefluxvar, real dt, int is,
                                int js, int ks, int i, int j, int k, int n) {
   SArray<real, 1, ndofs> Mf;
   SArray<real, 3, ndofs, ndims, 2> edgeflux;
@@ -183,8 +184,8 @@ void YAKL_INLINE calculate_phivert(SArray<real, 1, ndofs> &Phivert,
 }
 
 template <uint ndofs>
-YAKL_INLINE void compute_Phi(real5d Phivar, const real5d edgefluxvar,
-                             const real5d Mfvar, const real5d qvar, int is,
+YAKL_INLINE void compute_Phi(const real5d &Phivar, const real5d &edgefluxvar,
+                             const real5d &Mfvar, const real5d &qvar, int is,
                              int js, int ks, int i, int j, int k, int n) {
   SArray<real, 2, ndofs, ndims> Phi;
   SArray<real, 3, ndofs, ndims, 2> const q;
@@ -215,10 +216,10 @@ YAKL_INLINE void compute_Phi(real5d Phivar, const real5d edgefluxvar,
 }
 
 template <uint ndofs>
-YAKL_INLINE void compute_Phivert(real5d Phivertvar,
-                                 const real5d vertedgefluxvar,
-                                 const real5d Mfvar, const real5d qvar, int is,
-                                 int js, int ks, int i, int j, int k, int n) {
+YAKL_INLINE void
+compute_Phivert(const real5d &Phivertvar, const real5d &vertedgefluxvar,
+                const real5d &Mfvar, const real5d &qvar, int is, int js, int ks,
+                int i, int j, int k, int n) {
   SArray<real, 1, ndofs> Phivert;
   SArray<real, 2, ndofs, 2> const qvert;
   SArray<real, 2, ndofs, 2> const Mfvert;

--- a/dynamics/spam/src/operators/hodge_star.h
+++ b/dynamics/spam/src/operators/hodge_star.h
@@ -38,7 +38,7 @@ void YAKL_INLINE H(SArray<real, 1, ndims> &var,
 }
 
 template <uint ndofs, uint ord, uint off = ord / 2 - 1>
-void YAKL_INLINE compute_H(SArray<real, 1, ndims> &u, const real5d vvar,
+void YAKL_INLINE compute_H(SArray<real, 1, ndims> &u, const real5d &vvar,
                            const Geometry<Straight> &pgeom,
                            const Geometry<Twisted> &dgeom, int is, int js,
                            int ks, int i, int j, int k, int n) {
@@ -67,7 +67,7 @@ void YAKL_INLINE compute_H(SArray<real, 1, ndims> &u, const real5d vvar,
 
 template <uint ndofs, uint ord, ADD_MODE addmode = ADD_MODE::REPLACE,
           uint off = ord / 2 - 1>
-void YAKL_INLINE compute_H(real5d uvar, const real5d vvar,
+void YAKL_INLINE compute_H(const real5d &uvar, const real5d &vvar,
                            const Geometry<Straight> &pgeom,
                            const Geometry<Twisted> &dgeom, int is, int js,
                            int ks, int i, int j, int k, int n) {
@@ -140,7 +140,7 @@ void YAKL_INLINE fourier_H(SArray<real, 1, ndims> &u,
 }
 
 // Note the indexing here, this is key
-real YAKL_INLINE compute_Hv(const real5d wvar, const Geometry<Straight> &pgeom,
+real YAKL_INLINE compute_Hv(const real5d &wvar, const Geometry<Straight> &pgeom,
                             const Geometry<Twisted> &dgeom, int is, int js,
                             int ks, int i, int j, int k, int n) {
   // THIS IS 2ND ORDER AT BEST...
@@ -164,7 +164,7 @@ real YAKL_INLINE Hv_coeff(const Geometry<Straight> &pgeom,
 // fluxes, which are set diagnostically (=0 for no-flux bcs)
 template <uint ndofs, uint ord, ADD_MODE addmode = ADD_MODE::REPLACE,
           uint off = ord / 2 - 1>
-void YAKL_INLINE compute_Hv(real5d uwvar, const real5d wvar,
+void YAKL_INLINE compute_Hv(const real5d &uwvar, const real5d &wvar,
                             const Geometry<Straight> &pgeom,
                             const Geometry<Twisted> &dgeom, int is, int js,
                             int ks, int i, int j, int k, int n) {
@@ -178,7 +178,7 @@ void YAKL_INLINE compute_Hv(real5d uwvar, const real5d wvar,
 }
 template <uint ndofs, uint ord, ADD_MODE addmode = ADD_MODE::REPLACE,
           uint off = ord / 2 - 1>
-void YAKL_INLINE compute_Hv(SArray<real, 1, 1> &uwvar, const real5d wvar,
+void YAKL_INLINE compute_Hv(SArray<real, 1, 1> &uwvar, const real5d &wvar,
                             const Geometry<Straight> &pgeom,
                             const Geometry<Twisted> &dgeom, int is, int js,
                             int ks, int i, int j, int k, int n) {
@@ -194,7 +194,7 @@ void YAKL_INLINE compute_Hv(SArray<real, 1, 1> &uwvar, const real5d wvar,
 // BROKEN FOR 2D+1D EXT
 // MAINLY IN THE AREA CALCS...
 template <uint ndofs, uint ord, uint off = ord / 2 - 1>
-void YAKL_INLINE compute_Hext(SArray<real, 1, ndims> &u, const real5d vvar,
+void YAKL_INLINE compute_Hext(SArray<real, 1, ndims> &u, const real5d &vvar,
                               const Geometry<Straight> &pgeom,
                               const Geometry<Twisted> &dgeom, int is, int js,
                               int ks, int i, int j, int k, int n) {
@@ -223,7 +223,7 @@ void YAKL_INLINE compute_Hext(SArray<real, 1, ndims> &u, const real5d vvar,
 // boundary"
 template <uint ndofs, uint ord, ADD_MODE addmode = ADD_MODE::REPLACE,
           uint off = ord / 2 - 1>
-void YAKL_INLINE compute_Hext(real5d uvar, const real5d vvar,
+void YAKL_INLINE compute_Hext(const real5d &uvar, const real5d &vvar,
                               const Geometry<Straight> &pgeom,
                               const Geometry<Twisted> &dgeom, int is, int js,
                               int ks, int i, int j, int k, int n) {
@@ -322,7 +322,7 @@ void YAKL_INLINE I(SArray<real, 1, ndofs> &var,
 }
 
 template <uint ndofs, uint ord, uint off = ord / 2 - 1>
-void YAKL_INLINE compute_I(SArray<real, 1, ndofs> &x0, const real5d var,
+void YAKL_INLINE compute_I(SArray<real, 1, ndofs> &x0, const real5d &var,
                            const Geometry<Straight> &pgeom,
                            const Geometry<Twisted> &dgeom, int is, int js,
                            int ks, int i, int j, int k, int n) {
@@ -351,7 +351,7 @@ void YAKL_INLINE compute_I(SArray<real, 1, ndofs> &x0, const real5d var,
 
 template <uint ndofs, uint ord, ADD_MODE addmode = ADD_MODE::REPLACE,
           uint off = ord / 2 - 1>
-void YAKL_INLINE compute_I(real5d var0, const real5d var,
+void YAKL_INLINE compute_I(const real5d &var0, const real5d &var,
                            const Geometry<Straight> &pgeom,
                            const Geometry<Twisted> &dgeom, int is, int js,
                            int ks, int i, int j, int k, int n) {
@@ -417,7 +417,7 @@ real YAKL_INLINE fourier_I(const Geometry<Straight> &pgeom,
 // JUST IN THE AREA FORM CALCS...
 template <uint ndofs, uint hord, uint vord, uint hoff = hord / 2 - 1,
           uint voff = vord / 2 - 1>
-void YAKL_INLINE compute_Iext(SArray<real, 1, ndofs> &x0, const real5d var,
+void YAKL_INLINE compute_Iext(SArray<real, 1, ndofs> &x0, const real5d &var,
                               const Geometry<Straight> &pgeom,
                               const Geometry<Twisted> &dgeom, int is, int js,
                               int ks, int i, int j, int k, int n) {
@@ -451,7 +451,7 @@ void YAKL_INLINE compute_Iext(SArray<real, 1, ndofs> &x0, const real5d var,
 template <uint ndofs, uint hord, uint vord,
           ADD_MODE addmode = ADD_MODE::REPLACE, uint hoff = hord / 2 - 1,
           uint voff = vord / 2 - 1>
-void YAKL_INLINE compute_Iext(real5d var0, const real5d var,
+void YAKL_INLINE compute_Iext(const real5d &var0, const real5d &var,
                               const Geometry<Straight> &pgeom,
                               const Geometry<Twisted> &dgeom, int is, int js,
                               int ks, int i, int j, int k, int n) {
@@ -542,7 +542,7 @@ void YAKL_INLINE J(SArray<real, 1, ndofs> &var,
 }
 
 template <uint ndofs, uint ord, uint off = ord / 2 - 1>
-void YAKL_INLINE compute_J(SArray<real, 1, ndofs> &x0, const real5d var,
+void YAKL_INLINE compute_J(SArray<real, 1, ndofs> &x0, const real5d &var,
                            const Geometry<Straight> &pgeom,
                            const Geometry<Twisted> &dgeom, int is, int js,
                            int ks, int i, int j, int k, int n) {
@@ -571,7 +571,7 @@ void YAKL_INLINE compute_J(SArray<real, 1, ndofs> &x0, const real5d var,
 
 template <uint ndofs, uint ord, ADD_MODE addmode = ADD_MODE::REPLACE,
           uint off = ord / 2 - 1>
-void YAKL_INLINE compute_J(real5d var0, const real5d var,
+void YAKL_INLINE compute_J(const real5d &var0, const real5d &var,
                            const Geometry<Straight> &pgeom,
                            const Geometry<Twisted> &dgeom, int is, int js,
                            int ks, int i, int j, int k, int n) {
@@ -593,7 +593,7 @@ void YAKL_INLINE compute_J(real5d var0, const real5d var,
 // JUST IN THE AREA CALCS...
 template <uint ndofs, uint hord, uint vord, uint hoff = hord / 2 - 1,
           uint voff = vord / 2 - 1>
-void YAKL_INLINE compute_Jext(SArray<real, 1, ndofs> &x0, const real5d var,
+void YAKL_INLINE compute_Jext(SArray<real, 1, ndofs> &x0, const real5d &var,
                               const Geometry<Straight> &pgeom,
                               const Geometry<Twisted> &dgeom, int is, int js,
                               int ks, int i, int j, int k, int n) {
@@ -632,7 +632,7 @@ void YAKL_INLINE compute_Jext(SArray<real, 1, ndofs> &x0, const real5d var,
 template <uint ndofs, uint hord, uint vord,
           ADD_MODE addmode = ADD_MODE::REPLACE, uint hoff = hord / 2 - 1,
           uint voff = vord / 2 - 1>
-void YAKL_INLINE compute_Jext(real5d var0, const real5d var,
+void YAKL_INLINE compute_Jext(const real5d &var0, const real5d &var,
                               const Geometry<Straight> &pgeom,
                               const Geometry<Twisted> &dgeom, int is, int js,
                               int ks, int i, int j, int k, int n) {

--- a/dynamics/spam/src/operators/recon.h
+++ b/dynamics/spam/src/operators/recon.h
@@ -9,8 +9,8 @@
 template <uint ndofs, RECONSTRUCTION_TYPE recontype, uint ord, uint tord = 2,
           uint hs = (ord - 1) / 2>
 void YAKL_INLINE compute_twisted_edge_recon(
-    real5d edgereconvar, const real5d var, int is, int js, int ks, int i, int j,
-    int k, int n, SArray<real, 3, ord, ord, ord> const &wenoRecon,
+    const real5d &edgereconvar, const real5d &var, int is, int js, int ks,
+    int i, int j, int k, int n, SArray<real, 3, ord, ord, ord> const &wenoRecon,
     SArray<real, 2, ord, tord> const &to_gll,
     SArray<real, 1, hs + 2> const &wenoIdl, real wenoSigma) {
 
@@ -54,8 +54,8 @@ void YAKL_INLINE compute_twisted_edge_recon(
 template <uint ndofs, RECONSTRUCTION_TYPE recontype, uint ord, uint tord = 2,
           uint hs = (ord - 1) / 2>
 void YAKL_INLINE compute_twisted_vert_edge_recon(
-    real5d vertedgereconvar, const real5d var, int is, int js, int ks, int i,
-    int j, int k, int n, SArray<real, 3, ord, ord, ord> const &wenoRecon,
+    const real5d &vertedgereconvar, const real5d &var, int is, int js, int ks,
+    int i, int j, int k, int n, SArray<real, 3, ord, ord, ord> const &wenoRecon,
     SArray<real, 2, ord, tord> const &to_gll,
     SArray<real, 1, hs + 2> const &wenoIdl, real wenoSigma) {
   SArray<real, 3, ndofs, 1, ord> stencil;
@@ -89,8 +89,8 @@ void YAKL_INLINE compute_twisted_vert_edge_recon(
 template <uint ndofs, RECONSTRUCTION_TYPE recontype, uint ord, uint tord = 2,
           uint hs = (ord - 1) / 2>
 void YAKL_INLINE compute_straight_edge_recon(
-    real5d edgereconvar, const real5d var, int is, int js, int ks, int i, int j,
-    int k, int n, SArray<real, 3, ord, ord, ord> const &wenoRecon,
+    const real5d &edgereconvar, const real5d &var, int is, int js, int ks,
+    int i, int j, int k, int n, SArray<real, 3, ord, ord, ord> const &wenoRecon,
     SArray<real, 2, ord, tord> const &to_gll,
     SArray<real, 1, hs + 2> const &wenoIdl, real wenoSigma) {
 
@@ -135,8 +135,8 @@ void YAKL_INLINE compute_straight_edge_recon(
 template <uint ndofs, RECONSTRUCTION_TYPE recontype, uint ord, uint tord = 2,
           uint hs = (ord - 1) / 2>
 void YAKL_INLINE compute_straight_xz_edge_recon(
-    real5d edgereconvar, const real5d var, int is, int js, int ks, int i, int j,
-    int k, int n, SArray<real, 3, ord, ord, ord> const &wenoRecon,
+    const real5d &edgereconvar, const real5d &var, int is, int js, int ks,
+    int i, int j, int k, int n, SArray<real, 3, ord, ord, ord> const &wenoRecon,
     SArray<real, 2, ord, tord> const &to_gll,
     SArray<real, 1, hs + 2> const &wenoIdl, real wenoSigma) {
   SArray<real, 3, ndofs, 1, ord> stencil;
@@ -172,8 +172,8 @@ void YAKL_INLINE compute_straight_xz_edge_recon(
 template <uint ndofs, RECONSTRUCTION_TYPE recontype, uint ord, uint tord = 2,
           uint hs = (ord - 1) / 2>
 void YAKL_INLINE compute_straight_xz_vert_edge_recon(
-    real5d edgereconvar, const real5d var, int is, int js, int ks, int i, int j,
-    int k, int n, SArray<real, 3, ord, ord, ord> const &wenoRecon,
+    const real5d &edgereconvar, const real5d &var, int is, int js, int ks,
+    int i, int j, int k, int n, SArray<real, 3, ord, ord, ord> const &wenoRecon,
     SArray<real, 2, ord, tord> const &to_gll,
     SArray<real, 1, hs + 2> const &wenoIdl, real wenoSigma) {
   SArray<real, 3, ndofs, 1, ord> stencil;
@@ -235,9 +235,9 @@ void YAKL_INLINE upwind_recon(SArray<real, 2, ndofs, nd> &recon,
 }
 
 template <uint ndofs, RECONSTRUCTION_TYPE recontype>
-void YAKL_INLINE compute_twisted_recon(real5d reconvar,
-                                       const real5d edgereconvar,
-                                       const real5d U, int is, int js, int ks,
+void YAKL_INLINE compute_twisted_recon(const real5d &reconvar,
+                                       const real5d &edgereconvar,
+                                       const real5d &U, int is, int js, int ks,
                                        int i, int j, int k, int n) {
 
   SArray<real, 2, ndofs, ndims> recon;
@@ -280,9 +280,9 @@ void YAKL_INLINE compute_twisted_recon(real5d reconvar,
 }
 
 template <uint ndofs, RECONSTRUCTION_TYPE recontype>
-void YAKL_INLINE compute_twisted_vert_recon(real5d vertreconvar,
-                                            const real5d vertedgereconvar,
-                                            const real5d UW, int is, int js,
+void YAKL_INLINE compute_twisted_vert_recon(const real5d &vertreconvar,
+                                            const real5d &vertedgereconvar,
+                                            const real5d &UW, int is, int js,
                                             int ks, int i, int j, int k,
                                             int n) {
 
@@ -314,10 +314,10 @@ void YAKL_INLINE compute_twisted_vert_recon(real5d vertreconvar,
 }
 
 template <uint ndofs, RECONSTRUCTION_TYPE recontype>
-void YAKL_INLINE compute_straight_recon(real5d reconvar,
-                                        const real5d edgereconvar,
-                                        const real5d UT, int is, int js, int ks,
-                                        int i, int j, int k, int n) {
+void YAKL_INLINE compute_straight_recon(const real5d &reconvar,
+                                        const real5d &edgereconvar,
+                                        const real5d &UT, int is, int js,
+                                        int ks, int i, int j, int k, int n) {
   SArray<real, 2, ndofs, ndims> recon;
   SArray<real, 1, ndims> uvar;
   SArray<real, 3, ndofs, ndims, 2> edgerecon;
@@ -368,9 +368,9 @@ void YAKL_INLINE compute_straight_recon(real5d reconvar,
 }
 
 template <uint ndofs, RECONSTRUCTION_TYPE recontype>
-void YAKL_INLINE compute_straight_xz_recon(real5d reconvar,
-                                           const real5d edgereconvar,
-                                           const real5d WT, int is, int js,
+void YAKL_INLINE compute_straight_xz_recon(const real5d &reconvar,
+                                           const real5d &edgereconvar,
+                                           const real5d &WT, int is, int js,
                                            int ks, int i, int j, int k, int n) {
   SArray<real, 2, ndofs, 1> recon;
   SArray<real, 1, 1> uvar;
@@ -398,11 +398,11 @@ void YAKL_INLINE compute_straight_xz_recon(real5d reconvar,
 }
 
 template <uint ndofs, RECONSTRUCTION_TYPE recontype>
-void YAKL_INLINE compute_straight_xz_vert_recon(real5d reconvar,
-                                                const real5d edgereconvar,
-                                                const real5d VT, int is, int js,
-                                                int ks, int i, int j, int k,
-                                                int n) {
+void YAKL_INLINE compute_straight_xz_vert_recon(const real5d &reconvar,
+                                                const real5d &edgereconvar,
+                                                const real5d &VT, int is,
+                                                int js, int ks, int i, int j,
+                                                int k, int n) {
   SArray<real, 2, ndofs, 1> recon;
   SArray<real, 1, 1> uvar;
   SArray<real, 3, ndofs, 1, 2> edgerecon;

--- a/dynamics/spam/src/operators/wedge.h
+++ b/dynamics/spam/src/operators/wedge.h
@@ -40,8 +40,8 @@ void YAKL_INLINE Q2D_nonEC(SArray<real, 2, ndofs, 2> &vel,
 }
 
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-void YAKL_INLINE compute_Q_EC(real5d qflux, const real5d reconvar,
-                              const real5d Uvar, int is, int js, int ks, int i,
+void YAKL_INLINE compute_Q_EC(const real5d &qflux, const real5d &reconvar,
+                              const real5d &Uvar, int is, int js, int ks, int i,
                               int j, int k, int n) {
 
   SArray<real, 2, ndofs, 2> vel;
@@ -87,8 +87,8 @@ void YAKL_INLINE compute_Q_EC(real5d qflux, const real5d reconvar,
 }
 
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-void YAKL_INLINE compute_Q_nonEC(real5d qflux, const real5d reconvar,
-                                 const real5d Uvar, int is, int js, int ks,
+void YAKL_INLINE compute_Q_nonEC(const real5d &qflux, const real5d &reconvar,
+                                 const real5d &Uvar, int is, int js, int ks,
                                  int i, int j, int k, int n) {
 
   SArray<real, 2, ndofs, 2> vel;
@@ -125,10 +125,10 @@ void YAKL_INLINE compute_Q_nonEC(real5d qflux, const real5d reconvar,
 }
 
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-void YAKL_INLINE compute_Qxz_w_EC(real5d qflux, const real5d reconvar,
-                                  const real5d vertreconvar, const real5d Uvar,
-                                  int is, int js, int ks, int i, int j, int k,
-                                  int n) {
+void YAKL_INLINE compute_Qxz_w_EC(const real5d &qflux, const real5d &reconvar,
+                                  const real5d &vertreconvar,
+                                  const real5d &Uvar, int is, int js, int ks,
+                                  int i, int j, int k, int n) {
   SArray<real, 1, 4> flux;
   SArray<real, 1, 4> recon;
   flux(0) = Uvar(0, k + ks, j + js, i + is, n);
@@ -161,9 +161,10 @@ void YAKL_INLINE compute_Qxz_w_EC(real5d qflux, const real5d reconvar,
   }
 }
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-void YAKL_INLINE compute_Qxz_w_nonEC(real5d qflux, const real5d reconvar,
-                                     const real5d Uvar, int is, int js, int ks,
-                                     int i, int j, int k, int n) {
+void YAKL_INLINE compute_Qxz_w_nonEC(const real5d &qflux,
+                                     const real5d &reconvar, const real5d &Uvar,
+                                     int is, int js, int ks, int i, int j,
+                                     int k, int n) {
   SArray<real, 1, 4> flux;
   flux(0) = Uvar(0, k + ks, j + js, i + is, n);
   flux(1) = Uvar(0, k + ks, j + js, i + is + 1, n);
@@ -185,10 +186,11 @@ void YAKL_INLINE compute_Qxz_w_nonEC(real5d qflux, const real5d reconvar,
   }
 }
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-void YAKL_INLINE compute_Qxz_w_EC_top(real5d qflux, const real5d reconvar,
-                                      const real5d vertreconvar,
-                                      const real5d Uvar, int is, int js, int ks,
-                                      int i, int j, int k, int n) {
+void YAKL_INLINE compute_Qxz_w_EC_top(const real5d &qflux,
+                                      const real5d &reconvar,
+                                      const real5d &vertreconvar,
+                                      const real5d &Uvar, int is, int js,
+                                      int ks, int i, int j, int k, int n) {
   SArray<real, 1, 2> flux;
   SArray<real, 1, 2> recon;
   flux(0) = Uvar(0, k + ks, j + js, i + is, n);
@@ -211,8 +213,9 @@ void YAKL_INLINE compute_Qxz_w_EC_top(real5d qflux, const real5d reconvar,
   }
 }
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-void YAKL_INLINE compute_Qxz_w_nonEC_top(real5d qflux, const real5d reconvar,
-                                         const real5d Uvar, int is, int js,
+void YAKL_INLINE compute_Qxz_w_nonEC_top(const real5d &qflux,
+                                         const real5d &reconvar,
+                                         const real5d &Uvar, int is, int js,
                                          int ks, int i, int j, int k, int n) {
   SArray<real, 1, 2> flux;
   flux(0) = Uvar(0, k + ks, j + js, i + is, n);
@@ -233,9 +236,10 @@ void YAKL_INLINE compute_Qxz_w_nonEC_top(real5d qflux, const real5d reconvar,
   }
 }
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-void YAKL_INLINE compute_Qxz_w_EC_bottom(real5d qflux, const real5d reconvar,
-                                         const real5d vertreconvar,
-                                         const real5d Uvar, int is, int js,
+void YAKL_INLINE compute_Qxz_w_EC_bottom(const real5d &qflux,
+                                         const real5d &reconvar,
+                                         const real5d &vertreconvar,
+                                         const real5d &Uvar, int is, int js,
                                          int ks, int i, int j, int k, int n) {
   SArray<real, 1, 2> flux;
   SArray<real, 1, 2> recon;
@@ -259,8 +263,9 @@ void YAKL_INLINE compute_Qxz_w_EC_bottom(real5d qflux, const real5d reconvar,
   }
 }
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-void YAKL_INLINE compute_Qxz_w_nonEC_bottom(real5d qflux, const real5d reconvar,
-                                            const real5d Uvar, int is, int js,
+void YAKL_INLINE compute_Qxz_w_nonEC_bottom(const real5d &qflux,
+                                            const real5d &reconvar,
+                                            const real5d &Uvar, int is, int js,
                                             int ks, int i, int j, int k,
                                             int n) {
   SArray<real, 1, 2> flux;
@@ -283,10 +288,11 @@ void YAKL_INLINE compute_Qxz_w_nonEC_bottom(real5d qflux, const real5d reconvar,
 }
 
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-void YAKL_INLINE compute_Qxz_u_EC(real5d qvertflux, const real5d reconvar,
-                                  const real5d vertreconvar, const real5d UWvar,
-                                  int is, int js, int ks, int i, int j, int k,
-                                  int n) {
+void YAKL_INLINE compute_Qxz_u_EC(const real5d &qvertflux,
+                                  const real5d &reconvar,
+                                  const real5d &vertreconvar,
+                                  const real5d &UWvar, int is, int js, int ks,
+                                  int i, int j, int k, int n) {
   SArray<real, 1, 4> flux;
   SArray<real, 1, 4> recon;
   flux(0) = UWvar(0, k + ks, j + js, i + is, n);
@@ -322,10 +328,10 @@ void YAKL_INLINE compute_Qxz_u_EC(real5d qvertflux, const real5d reconvar,
   }
 }
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-void YAKL_INLINE compute_Qxz_u_nonEC(real5d qvertflux,
-                                     const real5d vertreconvar,
-                                     const real5d UWvar, int is, int js, int ks,
-                                     int i, int j, int k, int n) {
+void YAKL_INLINE compute_Qxz_u_nonEC(const real5d &qvertflux,
+                                     const real5d &vertreconvar,
+                                     const real5d &UWvar, int is, int js,
+                                     int ks, int i, int j, int k, int n) {
   SArray<real, 1, 4> flux;
   flux(0) = UWvar(0, k + ks, j + js, i + is, n);
   flux(1) = UWvar(0, k + ks, j + js, i + is - 1, n);
@@ -349,8 +355,9 @@ void YAKL_INLINE compute_Qxz_u_nonEC(real5d qvertflux,
 }
 
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-void YAKL_INLINE compute_Qxz_u_top(real5d qvertflux, const real5d vertreconvar,
-                                   const real5d UWvar, int is, int js, int ks,
+void YAKL_INLINE compute_Qxz_u_top(const real5d &qvertflux,
+                                   const real5d &vertreconvar,
+                                   const real5d &UWvar, int is, int js, int ks,
                                    int i, int j, int k, int n) {
   SArray<real, 1, 2> flux;
   flux(0) = UWvar(0, k + ks + 1, j + js, i + is, n);
@@ -372,9 +379,9 @@ void YAKL_INLINE compute_Qxz_u_top(real5d qvertflux, const real5d vertreconvar,
   }
 }
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-void YAKL_INLINE compute_Qxz_u_bottom(real5d qvertflux,
-                                      const real5d vertreconvar,
-                                      const real5d UWvar, int is, int js,
+void YAKL_INLINE compute_Qxz_u_bottom(const real5d &qvertflux,
+                                      const real5d &vertreconvar,
+                                      const real5d &UWvar, int is, int js,
                                       int ks, int i, int j, int k, int n) {
   SArray<real, 1, 2> flux;
   flux(0) = UWvar(0, k + ks, j + js, i + is, n);
@@ -396,35 +403,36 @@ void YAKL_INLINE compute_Qxz_u_bottom(real5d qvertflux,
   }
 }
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-void YAKL_INLINE compute_Qxz_u_nonEC_top(real5d qvertflux,
-                                         const real5d vertreconvar,
-                                         const real5d UWvar, int is, int js,
+void YAKL_INLINE compute_Qxz_u_nonEC_top(const real5d &qvertflux,
+                                         const real5d &vertreconvar,
+                                         const real5d &UWvar, int is, int js,
                                          int ks, int i, int j, int k, int n) {
   compute_Qxz_u_top<ndofs, addmode>(qvertflux, vertreconvar, UWvar, is, js, ks,
                                     i, j, k, n);
 }
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-void YAKL_INLINE compute_Qxz_u_EC_top(real5d qvertflux, const real5d reconvar,
-                                      const real5d vertreconvar,
-                                      const real5d UWvar, int is, int js,
+void YAKL_INLINE compute_Qxz_u_EC_top(const real5d &qvertflux,
+                                      const real5d &reconvar,
+                                      const real5d &vertreconvar,
+                                      const real5d &UWvar, int is, int js,
                                       int ks, int i, int j, int k, int n) {
   compute_Qxz_u_top<ndofs, addmode>(qvertflux, vertreconvar, UWvar, is, js, ks,
                                     i, j, k, n);
 }
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-void YAKL_INLINE compute_Qxz_u_nonEC_bottom(real5d qvertflux,
-                                            const real5d vertreconvar,
-                                            const real5d UWvar, int is, int js,
+void YAKL_INLINE compute_Qxz_u_nonEC_bottom(const real5d &qvertflux,
+                                            const real5d &vertreconvar,
+                                            const real5d &UWvar, int is, int js,
                                             int ks, int i, int j, int k,
                                             int n) {
   compute_Qxz_u_bottom<ndofs, addmode>(qvertflux, vertreconvar, UWvar, is, js,
                                        ks, i, j, k, n);
 }
 template <uint ndofs, ADD_MODE addmode = ADD_MODE::REPLACE>
-void YAKL_INLINE compute_Qxz_u_EC_bottom(real5d qvertflux,
-                                         const real5d reconvar,
-                                         const real5d vertreconvar,
-                                         const real5d UWvar, int is, int js,
+void YAKL_INLINE compute_Qxz_u_EC_bottom(const real5d &qvertflux,
+                                         const real5d &reconvar,
+                                         const real5d &vertreconvar,
+                                         const real5d &UWvar, int is, int js,
                                          int ks, int i, int j, int k, int n) {
   compute_Qxz_u_bottom<ndofs, addmode>(qvertflux, vertreconvar, UWvar, is, js,
                                        ks, i, j, k, n);
@@ -439,8 +447,8 @@ void YAKL_INLINE W2D(SArray<real, 1, 2> &vel,
   vel(1) = 0.25_fp * (flux(1, 0) + flux(1, 1) + flux(1, 2) + flux(1, 3));
 }
 
-void YAKL_INLINE compute_W(real5d UTvar, const real5d Uvar, int is, int js,
-                           int ks, int i, int j, int k, int n) {
+void YAKL_INLINE compute_W(const real5d &UTvar, const real5d &Uvar, int is,
+                           int js, int ks, int i, int j, int k, int n) {
 
   SArray<real, 1, 2> ut;
   SArray<real, 2, 2, 4> flux;
@@ -460,8 +468,8 @@ void YAKL_INLINE compute_W(real5d UTvar, const real5d Uvar, int is, int js,
 }
 
 // Wxz
-void YAKL_INLINE compute_Wxz_u(real5d VTvar, const real5d UWvar, int is, int js,
-                               int ks, int i, int j, int k, int n) {
+void YAKL_INLINE compute_Wxz_u(const real5d &VTvar, const real5d &UWvar, int is,
+                               int js, int ks, int i, int j, int k, int n) {
   SArray<real, 1, 4> flux;
   flux(0) = UWvar(0, k + ks, j + js, i + is, n);
   flux(1) = UWvar(0, k + ks, j + js, i + is - 1, n);
@@ -471,17 +479,18 @@ void YAKL_INLINE compute_Wxz_u(real5d VTvar, const real5d UWvar, int is, int js,
   VTvar(0, k + ks, j + js, i + is, n) =
       -0.25_fp * (flux(0) + flux(1) + flux(2) + flux(3));
 }
-void YAKL_INLINE compute_Wxz_u_top(real5d VTvar, const real5d UWvar, int is,
-                                   int js, int ks, int i, int j, int k, int n) {
+void YAKL_INLINE compute_Wxz_u_top(const real5d &VTvar, const real5d &UWvar,
+                                   int is, int js, int ks, int i, int j, int k,
+                                   int n) {
   SArray<real, 1, 2> flux;
   flux(0) = UWvar(0, k + ks + 1, j + js, i + is, n);
   flux(1) = UWvar(0, k + ks + 1, j + js, i + is - 1, n);
   // Added the minus sign here
   VTvar(0, k + ks, j + js, i + is, n) = -0.5_fp * (flux(0) + flux(1));
 }
-void YAKL_INLINE compute_Wxz_u_bottom(real5d VTvar, const real5d UWvar, int is,
-                                      int js, int ks, int i, int j, int k,
-                                      int n) {
+void YAKL_INLINE compute_Wxz_u_bottom(const real5d &VTvar, const real5d &UWvar,
+                                      int is, int js, int ks, int i, int j,
+                                      int k, int n) {
   SArray<real, 1, 4> flux;
   flux(0) = UWvar(0, k + ks, j + js, i + is, n);
   flux(1) = UWvar(0, k + ks, j + js, i + is - 1, n);
@@ -489,8 +498,8 @@ void YAKL_INLINE compute_Wxz_u_bottom(real5d VTvar, const real5d UWvar, int is,
   VTvar(0, k + ks, j + js, i + is, n) = -0.5_fp * (flux(0) + flux(1));
 }
 
-void YAKL_INLINE compute_Wxz_w(real5d WTvar, const real5d Uvar, int is, int js,
-                               int ks, int i, int j, int k, int n) {
+void YAKL_INLINE compute_Wxz_w(const real5d &WTvar, const real5d &Uvar, int is,
+                               int js, int ks, int i, int j, int k, int n) {
   SArray<real, 1, 4> flux;
   flux(0) = Uvar(0, k + ks, j + js, i + is, n);
   flux(1) = Uvar(0, k + ks, j + js, i + is + 1, n);
@@ -499,16 +508,17 @@ void YAKL_INLINE compute_Wxz_w(real5d WTvar, const real5d Uvar, int is, int js,
   WTvar(0, k + ks, j + js, i + is, n) =
       0.25_fp * (flux(0) + flux(1) + flux(2) + flux(3));
 }
-void YAKL_INLINE compute_Wxz_w_top(real5d WTvar, const real5d Uvar, int is,
-                                   int js, int ks, int i, int j, int k, int n) {
+void YAKL_INLINE compute_Wxz_w_top(const real5d &WTvar, const real5d &Uvar,
+                                   int is, int js, int ks, int i, int j, int k,
+                                   int n) {
   SArray<real, 1, 2> flux;
   flux(0) = Uvar(0, k + ks, j + js, i + is, n);
   flux(1) = Uvar(0, k + ks, j + js, i + is + 1, n);
   WTvar(0, k + ks, j + js, i + is, n) = 0.25_fp * (flux(0) + flux(1));
 }
-void YAKL_INLINE compute_Wxz_w_bottom(real5d WTvar, const real5d Uvar, int is,
-                                      int js, int ks, int i, int j, int k,
-                                      int n) {
+void YAKL_INLINE compute_Wxz_w_bottom(const real5d &WTvar, const real5d &Uvar,
+                                      int is, int js, int ks, int i, int j,
+                                      int k, int n) {
   SArray<real, 1, 2> flux;
   flux(0) = Uvar(0, k + ks + 1, j + js, i + is, n);
   flux(1) = Uvar(0, k + ks + 1, j + js, i + is + 1, n);
@@ -528,7 +538,7 @@ void YAKL_INLINE R(SArray<real, 1, 1> &vard, SArray<real, 1, 8> const &varp) {
 }
 
 template <uint dof>
-void YAKL_INLINE compute_R(real &var, const real5d densvar, int is, int js,
+void YAKL_INLINE compute_R(real &var, const real5d &densvar, int is, int js,
                            int ks, int i, int j, int k, int n) {
   SArray<real, 1, 1> dualdens;
   if (ndims == 1) {
@@ -561,8 +571,8 @@ void YAKL_INLINE compute_R(real &var, const real5d densvar, int is, int js,
 }
 
 template <uint dof>
-void YAKL_INLINE compute_R(real5d var, const real5d densvar, int is, int js,
-                           int ks, int i, int j, int k, int n) {
+void YAKL_INLINE compute_R(const real5d &var, const real5d &densvar, int is,
+                           int js, int ks, int i, int j, int k, int n) {
   real var2;
   compute_R<dof>(var2, densvar, is, js, ks, i, j, k, n);
   var(dof, k + ks, j + js, i + is, n) = var2;
@@ -581,8 +591,8 @@ void YAKL_INLINE phi(SArray<real, 1, ndims> &vare,
   }
 }
 
-void YAKL_INLINE compute_phi(real5d var, const real5d densvar, int is, int js,
-                             int ks, int i, int j, int k, int n) {
+void YAKL_INLINE compute_phi(const real5d &var, const real5d &densvar, int is,
+                             int js, int ks, int i, int j, int k, int n) {
   SArray<real, 1, ndims> xe;
   SArray<real, 2, ndims, 2> x0;
   for (int d = 0; d < ndims; d++) {
@@ -609,8 +619,8 @@ real YAKL_INLINE phiW(SArray<real, 1, 2> const &var0) {
   return 0.5_fp * (var0(0) + var0(1));
 }
 
-void YAKL_INLINE compute_phiW(real5d var, const real5d densvar, int is, int js,
-                              int ks, int i, int j, int k, int n) {
+void YAKL_INLINE compute_phiW(const real5d &var, const real5d &densvar, int is,
+                              int js, int ks, int i, int j, int k, int n) {
   SArray<real, 1, 2> x0;
   x0(0) = densvar(0, k + ks, j + js, i + is, n);
   x0(1) = densvar(0, k + ks - 1, j + js, i + is, n);
@@ -629,9 +639,9 @@ void YAKL_INLINE phiT(SArray<real, 1, 1> &ke,
 }
 
 template <ADD_MODE addmode = ADD_MODE::REPLACE>
-void YAKL_INLINE compute_phiT(real5d var, const real5d uvar, const real5d vvar,
-                              int is, int js, int ks, int i, int j, int k,
-                              int n) {
+void YAKL_INLINE compute_phiT(const real5d &var, const real5d &uvar,
+                              const real5d &vvar, int is, int js, int ks, int i,
+                              int j, int k, int n) {
   SArray<real, 1, 1> ke;
   SArray<real, 2, ndims, 2> u;
   SArray<real, 2, ndims, 2> v;
@@ -665,7 +675,7 @@ void YAKL_INLINE compute_phiT(real5d var, const real5d uvar, const real5d vvar,
 }
 void YAKL_INLINE compute_phiT(SArray<real, 1, 1> &var,
                               SArray<real, 2, ndims, 2> const &u,
-                              const real5d vvar, int is, int js, int ks, int i,
+                              const real5d &vvar, int is, int js, int ks, int i,
                               int j, int k, int n) {
   SArray<real, 2, ndims, 2> v;
   for (int d = 0; d < ndims; d++) {
@@ -691,9 +701,9 @@ real YAKL_INLINE phiTW(SArray<real, 1, 2> const &u,
 }
 
 template <ADD_MODE addmode = ADD_MODE::REPLACE>
-void YAKL_INLINE compute_phiTW(real5d var, const real5d uwvar,
-                               const real5d wvar, int is, int js, int ks, int i,
-                               int j, int k, int n) {
+void YAKL_INLINE compute_phiTW(const real5d &var, const real5d &uwvar,
+                               const real5d &wvar, int is, int js, int ks,
+                               int i, int j, int k, int n) {
   SArray<real, 1, 2> u;
   SArray<real, 1, 2> v;
   u(0) = uwvar(0, k + ks, j + js, i + is, n);
@@ -711,7 +721,7 @@ void YAKL_INLINE compute_phiTW(real5d var, const real5d uwvar,
 
 template <ADD_MODE addmode = ADD_MODE::REPLACE>
 void YAKL_INLINE compute_phiTW(SArray<real, 1, 1> &var,
-                               SArray<real, 1, 2> const &uw, const real5d wvar,
+                               SArray<real, 1, 2> const &uw, const real5d &wvar,
                                int is, int js, int ks, int i, int j, int k,
                                int n) {
   SArray<real, 1, 2> v;


### PR DESCRIPTION
Passing arrays by value in functions called inside computational loops on the CPU is slow because it triggers reference counting.