### PR TITLE
[PAM-C] Reduce the number of aux variables and fuse some kernels

### DIFF
--- a/dynamics/spam/src/extrudedmodel-common.h
+++ b/dynamics/spam/src/extrudedmodel-common.h
@@ -57,48 +57,40 @@ uint constexpr nconstant = 2;
 // primal grid reconstruction stuff- U, W, dens0, edgerecon, recon,
 // vertedgerecon, vertrecon fct stuff- Phi, Mf, edgeflux Q/W STUFF?
 
-uint constexpr nauxiliary = 34;
+uint constexpr nauxiliary = 28;
 
 #define FVAR 0
 #define BVAR 1
 #define KVAR 2
-#define HEVAR 3
-#define UVAR 4
-#define FWVAR 5
-#define HEWVAR 6
-#define UWVAR 7
+#define UVAR 3
+#define FWVAR 4
+#define UWVAR 5
 
-#define DENS0VAR 8
-#define DENSRECONVAR 9
-#define DENSEDGERECONVAR 10
-#define DENSVERTRECONVAR 11
-#define DENSVERTEDGERECONVAR 12
+#define DENS0VAR 6
+#define DENSRECONVAR 7
+#define DENSEDGERECONVAR 8
+#define DENSVERTRECONVAR 9
+#define DENSVERTEDGERECONVAR 10
 
-#define PHIVAR 13
-#define PHIVERTVAR 14
-#define EDGEFLUXVAR 15
-#define VERTEDGEFLUXVAR 16
-#define MFVAR 17
+#define PHIVAR 11
+#define PHIVERTVAR 12
+#define EDGEFLUXVAR 13
+#define VERTEDGEFLUXVAR 14
+#define MFVAR 15
 
-#define QXZ0VAR 18
-#define QXZRECONVAR 19
-#define QXZVERTRECONVAR 20
-#define QXZEDGERECONVAR 21
-#define QXZVERTEDGERECONVAR 22
-#define QXZFLUXVAR 23
-#define QXZVERTFLUXVAR 24
+#define QXZ0VAR 16
+#define QXZRECONVAR 17
+#define QXZVERTRECONVAR 18
+#define QXZEDGERECONVAR 19
+#define QXZVERTEDGERECONVAR 20
+#define QXZFLUXVAR 21
+#define QXZVERTFLUXVAR 22
 
-#define FTVAR 25
-#define FTWVAR 26
-
-#define FXZ0VAR 27
-#define CORIOLISXZRECONVAR 28
-#define CORIOLISXZEDGERECONVAR 29
-#define CORIOLISXZVERTRECONVAR 30
-#define CORIOLISXZVERTEDGERECONVAR 31
-
-#define FVAR2 32
-#define FWVAR2 33
+#define FXZ0VAR 23
+#define CORIOLISXZRECONVAR 24
+#define CORIOLISXZEDGERECONVAR 25
+#define CORIOLISXZVERTRECONVAR 26
+#define CORIOLISXZVERTEDGERECONVAR 27
 
 // track total densities, dens min/max, energy (total, K, P, I), PV, PE
 uint constexpr nstats = 6;

--- a/dynamics/spam/src/hamiltonians/variableset.h
+++ b/dynamics/spam/src/hamiltonians/variableset.h
@@ -441,6 +441,13 @@ void VariableSetBase<VS_CE>::initialize(PamCoupler &coupler,
 }
 
 template <>
+real YAKL_INLINE VariableSetBase<VS_CE>::get_total_density(
+    const real5d &densvar, int k, int j, int i, int ks, int js, int is,
+    int n) const {
+  return densvar(0, k + ks, j + js, i + is, n);
+}
+
+template <>
 real YAKL_INLINE VariableSetBase<VS_CE>::get_entropic_var(const real5d &densvar,
                                                           int k, int j, int i,
                                                           int ks, int js,

--- a/dynamics/spam/src/operators/hodge_star.h
+++ b/dynamics/spam/src/operators/hodge_star.h
@@ -446,6 +446,41 @@ void YAKL_INLINE compute_Iext(SArray<real, 1, ndofs> &x0, const real5d &var,
   //  BUT THIS IS 2nd ORDER RIGHT NOW!
 }
 
+// version of Iext that applies a transformation before computing x0
+// mainly used to apply Iext to total density
+template <uint hord, uint vord, uint hoff = hord / 2 - 1,
+          uint voff = vord / 2 - 1, class F>
+real YAKL_INLINE compute_Iext(F f, const real5d &var,
+                              const Geometry<Straight> &pgeom,
+                              const Geometry<Twisted> &dgeom, int is, int js,
+                              int ks, int i, int j, int k, int n) {
+
+  SArray<real, 1, 1> x0;
+  SArray<real, 3, 1, ndims, hord - 1> x;
+  SArray<real, 2, ndims, hord - 1> Igeom;
+  for (int p = 0; p < hord - 1; p++) {
+    for (int d = 0; d < ndims; d++) {
+      if (d == 0) {
+        x(0, d, p) = f(var, k + ks, j + js, i + is + p - hoff, n);
+        Igeom(d, p) =
+            pgeom.get_area_00entity(k + ks, j + js, i + is + p - hoff) /
+            dgeom.get_area_11entity(k + ks, j + js, i + is + p - hoff);
+      }
+      if (d == 1) {
+        x(0, d, p) = f(var, k + ks, j + js + p - hoff, i + is, n);
+        Igeom(d, p) =
+            pgeom.get_area_00entity(k + ks, j + js + p - hoff, i + is) /
+            dgeom.get_area_11entity(k + ks, j + js + p - hoff, i + is);
+      }
+    }
+  }
+  I<1>(x0, x, Igeom);
+  // EVENTUALLY BE MORE CLEVER IN THE VERTICAL HERE
+  //  BUT THIS IS 2nd ORDER RIGHT NOW!
+
+  return x0(0);
+}
+
 // Indexing here is fine, since we going from d11 to p00 and there is no
 // "extended" boundary in p00
 template <uint ndofs, uint hord, uint vord,

--- a/dynamics/spam/src/operators/wedge.h
+++ b/dynamics/spam/src/operators/wedge.h
@@ -467,62 +467,97 @@ void YAKL_INLINE compute_W(const real5d &UTvar, const real5d &Uvar, int is,
   UTvar(1, k + ks, j + js, i + is, n) = ut(1);
 }
 
+void YAKL_INLINE Wxz_u(SArray<real, 1, 1> &vel,
+                       SArray<real, 1, 4> const &flux) {
+  // Added the minus sign here
+  vel(0) = -0.25_fp * (flux(0) + flux(1) + flux(2) + flux(3));
+}
+void YAKL_INLINE Wxz_u_boundary(SArray<real, 1, 1> &vel,
+                                SArray<real, 1, 2> const &flux) {
+
+  // Added the minus sign here
+  vel(0) = -0.5_fp * (flux(0) + flux(1));
+}
+
 // Wxz
 void YAKL_INLINE compute_Wxz_u(const real5d &VTvar, const real5d &UWvar, int is,
                                int js, int ks, int i, int j, int k, int n) {
   SArray<real, 1, 4> flux;
+  SArray<real, 1, 1> vel;
   flux(0) = UWvar(0, k + ks, j + js, i + is, n);
   flux(1) = UWvar(0, k + ks, j + js, i + is - 1, n);
   flux(2) = UWvar(0, k + ks + 1, j + js, i + is, n);
   flux(3) = UWvar(0, k + ks + 1, j + js, i + is - 1, n);
-  // Added the minus sign here
-  VTvar(0, k + ks, j + js, i + is, n) =
-      -0.25_fp * (flux(0) + flux(1) + flux(2) + flux(3));
+
+  Wxz_u(vel, flux);
+  VTvar(0, k + ks, j + js, i + is, n) = vel(0);
 }
 void YAKL_INLINE compute_Wxz_u_top(const real5d &VTvar, const real5d &UWvar,
                                    int is, int js, int ks, int i, int j, int k,
                                    int n) {
   SArray<real, 1, 2> flux;
+  SArray<real, 1, 1> vel;
   flux(0) = UWvar(0, k + ks + 1, j + js, i + is, n);
   flux(1) = UWvar(0, k + ks + 1, j + js, i + is - 1, n);
-  // Added the minus sign here
-  VTvar(0, k + ks, j + js, i + is, n) = -0.5_fp * (flux(0) + flux(1));
+
+  Wxz_u_boundary(vel, flux);
+  VTvar(0, k + ks, j + js, i + is, n) = vel(0);
 }
 void YAKL_INLINE compute_Wxz_u_bottom(const real5d &VTvar, const real5d &UWvar,
                                       int is, int js, int ks, int i, int j,
                                       int k, int n) {
-  SArray<real, 1, 4> flux;
+  SArray<real, 1, 2> flux;
+  SArray<real, 1, 1> vel;
   flux(0) = UWvar(0, k + ks, j + js, i + is, n);
   flux(1) = UWvar(0, k + ks, j + js, i + is - 1, n);
-  // Added the minus sign here
-  VTvar(0, k + ks, j + js, i + is, n) = -0.5_fp * (flux(0) + flux(1));
+
+  Wxz_u_boundary(vel, flux);
+  VTvar(0, k + ks, j + js, i + is, n) = vel(0);
+}
+
+void YAKL_INLINE Wxz_w(SArray<real, 1, 1> &vel,
+                       SArray<real, 1, 4> const &flux) {
+  vel(0) = 0.25_fp * (flux(0) + flux(1) + flux(2) + flux(3));
+}
+void YAKL_INLINE Wxz_w_boundary(SArray<real, 1, 1> &vel,
+                                SArray<real, 1, 2> const &flux) {
+
+  vel(0) = 0.25_fp * (flux(0) + flux(1));
 }
 
 void YAKL_INLINE compute_Wxz_w(const real5d &WTvar, const real5d &Uvar, int is,
                                int js, int ks, int i, int j, int k, int n) {
   SArray<real, 1, 4> flux;
+  SArray<real, 1, 1> vel;
   flux(0) = Uvar(0, k + ks, j + js, i + is, n);
   flux(1) = Uvar(0, k + ks, j + js, i + is + 1, n);
   flux(2) = Uvar(0, k + ks + 1, j + js, i + is, n);
   flux(3) = Uvar(0, k + ks + 1, j + js, i + is + 1, n);
-  WTvar(0, k + ks, j + js, i + is, n) =
-      0.25_fp * (flux(0) + flux(1) + flux(2) + flux(3));
+
+  Wxz_w(vel, flux);
+  WTvar(0, k + ks, j + js, i + is, n) = vel(0);
 }
 void YAKL_INLINE compute_Wxz_w_top(const real5d &WTvar, const real5d &Uvar,
                                    int is, int js, int ks, int i, int j, int k,
                                    int n) {
   SArray<real, 1, 2> flux;
+  SArray<real, 1, 1> vel;
   flux(0) = Uvar(0, k + ks, j + js, i + is, n);
   flux(1) = Uvar(0, k + ks, j + js, i + is + 1, n);
-  WTvar(0, k + ks, j + js, i + is, n) = 0.25_fp * (flux(0) + flux(1));
+
+  Wxz_w_boundary(vel, flux);
+  WTvar(0, k + ks, j + js, i + is, n) = vel(0);
 }
 void YAKL_INLINE compute_Wxz_w_bottom(const real5d &WTvar, const real5d &Uvar,
                                       int is, int js, int ks, int i, int j,
                                       int k, int n) {
   SArray<real, 1, 2> flux;
+  SArray<real, 1, 1> vel;
   flux(0) = Uvar(0, k + ks + 1, j + js, i + is, n);
   flux(1) = Uvar(0, k + ks + 1, j + js, i + is + 1, n);
-  WTvar(0, k + ks, j + js, i + is, n) = 0.25_fp * (flux(0) + flux(1));
+
+  Wxz_w_boundary(vel, flux);
+  WTvar(0, k + ks, j + js, i + is, n) = vel(0);
 }
 
 // R


### PR DESCRIPTION
The following auxiliary variables got removed: `HE`, `HEW`, `FT`, `FTW`, `F2`, `FW2`.