### PR TITLE
[PAM-C] Fix compilation of layer model

### DIFF
--- a/dynamics/spam/src/models/layermodel.h
+++ b/dynamics/spam/src/models/layermodel.h
@@ -323,7 +323,7 @@ public:
                       real5d Coriolisreconvar, const real5d densedgereconvar,
                       const real5d Qedgereconvar, const real5d fedgereconvar,
                       const real5d HEvar, const real5d FTvar,
-                      const real5d Uvar) {
+                      const real5d Vvar) {
     const auto &primal_topology = primal_geometry.topology;
     const auto &dual_topology = dual_geometry.topology;
 
@@ -351,9 +351,10 @@ public:
         "Compute twisted recons",
         SimpleBounds<4>(dual_topology.nl, dual_topology.n_cells_y,
                         dual_topology.n_cells_x, dual_topology.nens),
-        YAKL_LAMBDA(int k, int j, int i, int n) {
+        YAKL_CLASS_LAMBDA(int k, int j, int i, int n) {
           compute_twisted_recon<ndensity, dual_reconstruction_type>(
-              densreconvar, densedgereconvar, Uvar, dis, djs, dks, i, j, k, n);
+              densreconvar, densedgereconvar, this->primal_geometry,
+              this->dual_geometry, Vvar, dis, djs, dks, i, j, k, n);
           // scale primal recons
           for (int d = 0; d < ndims; d++) {
             for (int l = 0; l < ndensity; l++) {
@@ -500,7 +501,7 @@ public:
                    auxiliary_vars.fields_arr[CORIOLISEDGERECONVAR].data,
                    auxiliary_vars.fields_arr[HEVAR].data,
                    auxiliary_vars.fields_arr[FTVAR].data,
-                   auxiliary_vars.fields_arr[UVAR].data);
+                   x.fields_arr[VVAR].data);
 
     auxiliary_vars.exchange({DENSRECONVAR, QRECONVAR, CORIOLISRECONVAR});
 

--- a/dynamics/spam/src/operators/recon.h
+++ b/dynamics/spam/src/operators/recon.h
@@ -246,7 +246,11 @@ void YAKL_INLINE compute_twisted_recon(const real5d &reconvar,
   SArray<real, 1, ndims> uvar;
   SArray<real, 3, ndofs, ndims, 2> edgerecon;
 
+#ifdef _EXTRUDED
   compute_Hext<1, diff_ord>(uvar, V, pgeom, dgeom, is, js, ks, i, j, k, n);
+#else
+  compute_H<1, diff_ord>(uvar, V, pgeom, dgeom, is, js, ks, i, j, k, n);
+#endif
 
   for (int d = 0; d < ndims; d++) {
     for (int l = 0; l < ndofs; l++) {
@@ -370,6 +374,7 @@ void YAKL_INLINE compute_straight_recon(const real5d &reconvar,
   }
 }
 
+#ifdef _EXTRUDED
 template <uint ndofs, RECONSTRUCTION_TYPE recontype>
 void YAKL_INLINE compute_straight_xz_recon(const real5d &reconvar,
                                            const real5d &edgereconvar,
@@ -466,3 +471,4 @@ void YAKL_INLINE compute_straight_xz_vert_recon(
     reconvar(l, k + ks, j + js, i + is, n) = recon(l, 0);
   }
 }
+#endif


### PR DESCRIPTION
This PR fixes the compilation of layer model which got broken by #50 due to changes in `compute_twisted_recon` that  were only made in the extruded model.