### PR TITLE
[PAM-C] Fix possible compilation failure introduced in #122

### DIFF
--- a/dynamics/spam/src/timesteppers/SI_Newton.h
+++ b/dynamics/spam/src/timesteppers/SI_Newton.h
@@ -8,16 +8,6 @@
 #include "topology.h"
 #include <sstream>
 
-real norm(FieldSet<nprognostic> &x) {
-  // note that this function assumes that x halos have been exchanged
-  real accum = 0;
-  for (auto f : x.fields_arr) {
-    accum = std::max(yakl::intrinsics::maxval(yakl::intrinsics::abs(f.data)),
-                     accum);
-  }
-  return accum;
-}
-
 template <uint nquad> class SINewtonTimeIntegrator : public TimeIntegrator {
 
 public:

--- a/dynamics/spam/src/timesteppers/time_integrator.h
+++ b/dynamics/spam/src/timesteppers/time_integrator.h
@@ -1,5 +1,19 @@
 #pragma once
 
+#include "common.h"
+#include "field_sets.h"
+#include "model.h"
+
+real norm(FieldSet<nprognostic> &x) {
+  // note that this function assumes that x halos have been exchanged
+  real accum = 0;
+  for (auto f : x.fields_arr) {
+    accum = std::max(yakl::intrinsics::maxval(yakl::intrinsics::abs(f.data)),
+                     accum);
+  }
+  return accum;
+}
+
 class TimeIntegrator {
 public:
   bool is_initialized = false;


### PR DESCRIPTION
`norm` needs to be defined in a header common to both semi-implicit time steppers.