### PR TITLE
Add basic CI using GitHub Actions

### DIFF
--- a/.github/workflows/mmf-simplified-macos.yml
+++ b/.github/workflows/mmf-simplified-macos.yml
@@ -1,0 +1,35 @@
+name: mmf-simplified-macos
+
+on: [push, pull_request]
+
+jobs:
+  mmf-simplified-macos:
+    runs-on: macos-12
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler:
+          - clang
+        dycore:
+          - pamc
+          - pama
+    defaults:
+      run:
+        working-directory: standalone/mmf_simplified/build
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install mpi and netcdf
+        run: brew install open-mpi netcdf
+
+      - name: Configure and build
+        run: |
+          source ../../machines/ci/macos-${{matrix.compiler}}.env &&
+          YAKL_CXX_FLAGS="${YAKL_CXX_FLAGS} -DYAKL_DEBUG"
+          ./cmakescript_${{matrix.dycore}}.sh &&
+          cmake --build .
+
+      - name: Run driver
+        run: ./driver ../inputs/ci/input_${{matrix.dycore}}.yaml

--- a/.github/workflows/mmf-simplified-ubuntu.yml
+++ b/.github/workflows/mmf-simplified-ubuntu.yml
@@ -1,0 +1,36 @@
+name: mmf-simplified-ubuntu
+
+on: [push, pull_request]
+
+jobs:
+  mmf-simplified-ubuntu:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler:
+          - gcc
+          - clang
+        dycore:
+          - pamc
+          - pama
+    defaults:
+      run:
+        working-directory: standalone/mmf_simplified/build
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install mpi and netcdf
+        run: sudo apt-get install -y libopenmpi-dev libnetcdf-dev
+
+      - name: Configure and build
+        run: |
+          source ../../machines/ci/ubuntu-${{matrix.compiler}}.env &&
+          YAKL_CXX_FLAGS="${YAKL_CXX_FLAGS} -DYAKL_DEBUG"
+          ./cmakescript_${{matrix.dycore}}.sh &&
+          cmake --build .
+
+      - name: Run driver
+        run: ./driver ../inputs/ci/input_${{matrix.dycore}}.yaml

--- a/.github/workflows/pamc-idealized-ubuntu.yml
+++ b/.github/workflows/pamc-idealized-ubuntu.yml
@@ -1,0 +1,48 @@
+name: pamc-idealized-ubuntu
+
+on: [push, pull_request]
+
+jobs:
+  pamc-idealized-ubuntu:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - model: layermodel
+            hamiltonian: swe
+            thermo: none
+          - model: layermodel
+            hamiltonian: tswe
+            thermo: none
+          - model: extrudedmodel
+            hamiltonian: ce
+            thermo: idealgaspottemp
+          - model: extrudedmodel
+            hamiltonian: ce
+            thermo: idealgasentropy
+          - model: extrudedmodel
+            hamiltonian: an
+            thermo: idealgaspottemp
+          - model: extrudedmodel
+            hamiltonian: mce_rho
+            thermo: constkappavirpottemp
+          - model: extrudedmodel
+            hamiltonian: man
+            thermo: constkappavirpottemp
+    defaults:
+      run:
+        working-directory: standalone/idealized/build
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install mpi and netcdf
+        run: sudo apt-get install -y libopenmpi-dev libnetcdf-dev
+
+      - name: Configure and build
+        run: |
+          source ../../machines/ci/ubuntu-gcc.env &&
+          ./cmakescript_pamc.sh ${{matrix.model}} ${{matrix.hamiltonian}} ${{matrix.thermo}} &&
+          cmake --build .

--- a/.github/workflows/pamc-unit-macos.yml
+++ b/.github/workflows/pamc-unit-macos.yml
@@ -1,0 +1,31 @@
+name: pamc-unit-macos
+
+on: [push, pull_request]
+
+jobs:
+  pamc-unit-macos:
+    runs-on: macos-12
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler:
+          - clang
+    defaults:
+      run:
+        working-directory: dynamics/spam/test/build
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install mpi and netcdf
+        run: brew install open-mpi netcdf
+
+      - name: Configure and build
+        run: |
+          source ../../../../standalone/machines/ci/macos-${{matrix.compiler}}.env &&
+          ./cmakescript.sh &&
+          cmake --build .
+
+      - name: Run tests
+        run: ctest --output-on-failure

--- a/.github/workflows/pamc-unit-ubuntu.yml
+++ b/.github/workflows/pamc-unit-ubuntu.yml
@@ -1,0 +1,32 @@
+name: pamc-unit-ubuntu
+
+on: [push, pull_request]
+
+jobs:
+  pamc-unit-ubuntu:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler:
+          - gcc
+          - clang
+    defaults:
+      run:
+        working-directory: dynamics/spam/test/build
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install mpi and netcdf
+        run: sudo apt-get install -y libopenmpi-dev libnetcdf-dev
+
+      - name: Configure and build
+        run: |
+          source ../../../../standalone/machines/ci/ubuntu-${{matrix.compiler}}.env &&
+          ./cmakescript.sh &&
+          cmake --build .
+
+      - name: Run tests
+        run: ctest --output-on-failure

--- a/dynamics/spam/test/build/cmakescript.sh
+++ b/dynamics/spam/test/build/cmakescript.sh
@@ -3,7 +3,6 @@
 ./cmakeclean.sh
 
 cmake      \
-  -DCMAKE_CXX_COMPILER=${CXX}                    \
   -DCMAKE_CUDA_HOST_COMPILER=${CXX}              \
   -DYAKL_CUDA_FLAGS="${YAKL_CUDA_FLAGS}"         \
   -DYAKL_CXX_FLAGS="${YAKL_CXX_FLAGS}"           \

--- a/standalone/idealized/build/cmakescript_pamc.sh
+++ b/standalone/idealized/build/cmakescript_pamc.sh
@@ -2,6 +2,10 @@
 
 ./cmakeclean.sh
 
+ARG1=${1:-"extrudedmodel"}
+ARG2=${2:-"man"}
+ARG3=${3:-"constkappavirpottemp"}
+
 cmake      \
   -DCMAKE_CXX_COMPILER=${CXX}                                     \
   -DCMAKE_CUDA_HOST_COMPILER=${CXX}                               \
@@ -17,8 +21,8 @@ cmake      \
   -DPAM_MICRO="none"                                              \
   -DPAM_SGS="none"                                                \
   -DPAM_RAD="none"                                                \
-  -DPAMC_MODEL="extrudedmodel"                                    \
-  -DPAMC_HAMIL="man"                                              \
-  -DPAMC_THERMO="constkappavirpottemp"                            \
+  -DPAMC_MODEL=$ARG1                                              \
+  -DPAMC_HAMIL=$ARG2                                              \
+  -DPAMC_THERMO=$ARG3                                             \
   -DPAMC_IO="serial"                                              \
   ..

--- a/standalone/machines/ci/macos-clang.env
+++ b/standalone/machines/ci/macos-clang.env
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+export YAKL_ARCH=
+unset CXXFLAGS
+unset FFLAGS
+unset F77FLAGS
+unset F90FLAGS
+
+export CC=mpicc
+export CXX=mpic++
+export FC=mpifort
+
+export OMPI_CC=clang
+export OMPI_CXX=clang++
+export OMPI_FC=gfortran-12
+
+export YAKL_CXX_FLAGS="-DHAVE_MPI -O2 -I`nc-config --includedir`"
+export YAKL_F90_FLAGS="-O2 -ffree-line-length-none"
+export PAM_LINK_FLAGS="-L`nc-config --libdir` -lnetcdf"
+export PAM_NLEV=50
+export PAM_SCREAM_USE_CXX="OFF"

--- a/standalone/machines/ci/ubuntu-clang.env
+++ b/standalone/machines/ci/ubuntu-clang.env
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+export YAKL_ARCH=
+unset CXXFLAGS
+unset FFLAGS
+unset F77FLAGS
+unset F90FLAGS
+
+export CC=mpicc
+export CXX=mpic++
+export FC=mpifort
+
+export OMPI_CC=clang
+export OMPI_CXX=clang++
+export OMPI_FC=gfortran
+
+export YAKL_CXX_FLAGS="-DHAVE_MPI -O2 -I`nc-config --includedir`"
+export YAKL_F90_FLAGS="-O2 -ffree-line-length-none"
+export PAM_LINK_FLAGS="-L`nc-config --libdir` -lnetcdf"
+export PAM_NLEV=50
+export PAM_SCREAM_USE_CXX="OFF"

--- a/standalone/machines/ci/ubuntu-gcc.env
+++ b/standalone/machines/ci/ubuntu-gcc.env
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+export YAKL_ARCH=
+unset CXXFLAGS
+unset FFLAGS
+unset F77FLAGS
+unset F90FLAGS
+
+export CC=mpicc
+export CXX=mpic++
+export FC=mpifort
+
+export OMPI_CC=gcc
+export OMPI_CXX=g++
+export OMPI_FC=gfortran
+
+export YAKL_CXX_FLAGS="-DHAVE_MPI -O2 -I`nc-config --includedir`"
+export YAKL_F90_FLAGS="-O2 -ffree-line-length-none"
+export PAM_LINK_FLAGS="-L`nc-config --libdir` -lnetcdf"
+export PAM_NLEV=50
+export PAM_SCREAM_USE_CXX="OFF"

--- a/standalone/mmf_simplified/inputs/ci/input_pama.yaml
+++ b/standalone/mmf_simplified/inputs/ci/input_pama.yaml
@@ -1,0 +1,36 @@
+---
+simTime : 1800 # 2 GCM time steps
+
+# Number of cells to use in the CRMs
+crm_nx   : 65
+crm_ny   : 1
+
+# Number of CRMs
+nens     : 1
+
+# Vertical height cooridnates file
+vcoords  : vcoords_equal_50_20km.nc
+
+# Domain size of the CRMs
+xlen     : 128000
+ylen     : 64000
+
+weno_scalars : true
+
+weno_winds   : true
+
+initData : supercell
+
+# Output filename
+out_prefix  : test_pama
+
+# GCM time step
+dt_gcm: 900
+
+# CRM physics time step
+dt_crm_phys: 20.
+
+# Output frequency in seconds
+out_freq: 200.
+
+

--- a/standalone/mmf_simplified/inputs/ci/input_pamc.yaml
+++ b/standalone/mmf_simplified/inputs/ci/input_pamc.yaml
@@ -1,0 +1,28 @@
+---
+simTime  : 1800   # 2 GCM time steps
+
+# Number of cells to use in the CRMs
+crm_nx   : 65
+crm_ny   : 1
+
+# Number of CRMs
+nens     : 1
+
+# Vertical height cooridnates file
+vcoords  : vcoords_equal_50_20km.nc
+
+# Domain size of the CRMs
+xlen     : 128000
+ylen     : 64000
+
+# Output filename
+out_prefix  : test_pamc
+
+# GCM time step
+dt_gcm: 900
+
+# CRM physics time step
+dt_crm_phys: 20.
+
+# Output frequency in seconds
+out_freq: 200.


### PR DESCRIPTION
This PR adds basic CI for PAM using GitHub Actions.

The CI currently does three checks:
 - builds and runs PAM-C unit tests.
 - builds (but not runs) PAM-C idealized solvers for different combinations of models, hamiltonians, and thermodynamics.
 - builds and runs PAM-C and PAM-A mmf_simplified driver for two GCM time steps with YAKL_DEBUG turned on.

All of this is tested on Ubuntu with both GCC and Clang and on MacOS with Clang, except for PAM-C compilation tests
which are done only on Ubuntu using GCC to avoid creating too many jobs.

This is very bare-bones, but I think it is a decent start. Notably, there are no tests with CXX physics. Suggestions for
more and better tests are very welcome.
