### PR TITLE
[PAM-C] Generalize diffusion

### DIFF
--- a/.github/workflows/mmf-simplified-ubuntu.yml
+++ b/.github/workflows/mmf-simplified-ubuntu.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Apt-get update
+        run: sudo apt-get update
+
       - name: Install mpi and netcdf
         run: sudo apt-get install -y libopenmpi-dev libnetcdf-dev
 

--- a/.github/workflows/pamc-idealized-ubuntu.yml
+++ b/.github/workflows/pamc-idealized-ubuntu.yml
@@ -38,6 +38,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Apt-get update
+        run: sudo apt-get update
+
       - name: Install mpi and netcdf
         run: sudo apt-get install -y libopenmpi-dev libnetcdf-dev
 

--- a/.github/workflows/pamc-unit-ubuntu.yml
+++ b/.github/workflows/pamc-unit-ubuntu.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Apt-get update
+        run: sudo apt-get update
+
       - name: Install mpi and netcdf
         run: sudo apt-get install -y libopenmpi-dev libnetcdf-dev
 

--- a/dynamics/spam/src/extrudedmodel-common.h
+++ b/dynamics/spam/src/extrudedmodel-common.h
@@ -34,7 +34,7 @@ int constexpr CORIOLISXYVAR = 2;
 // primal grid reconstruction stuff- U, W, dens0, edgerecon, recon,
 // vertedgerecon, vertrecon fct stuff- Phi, Mf, edgeflux Q/W STUFF?
 
-uint constexpr nauxiliary = ndims > 1 ? 37 : 30;
+uint constexpr nauxiliary = ndims > 1 ? 39 : 32;
 
 int constexpr FVAR = 0;
 int constexpr BVAR = 1;
@@ -72,14 +72,17 @@ int constexpr FW2VAR = 27;
 int constexpr FTVAR = 28;
 int constexpr FTWVAR = 29;
 
+int constexpr FDIFFVAR = 30;
+int constexpr FWDIFFVAR = 31;
+
 // 3d auxiliary variables
-int constexpr QXYVAR = 30;
-int constexpr QXYRECONVAR = 31;
-int constexpr QXYEDGERECONVAR = 32;
-int constexpr FXYVAR = 33;
-int constexpr CORIOLISXYRECONVAR = 34;
-int constexpr CORIOLISXYEDGERECONVAR = 35;
-int constexpr FTXYVAR = 36;
+int constexpr QXYVAR = 32;
+int constexpr QXYRECONVAR = 33;
+int constexpr QXYEDGERECONVAR = 34;
+int constexpr FXYVAR = 35;
+int constexpr CORIOLISXYRECONVAR = 36;
+int constexpr CORIOLISXYEDGERECONVAR = 37;
+int constexpr FTXYVAR = 38;
 
 // track total densities, dens min/max, energy (total, K, P, I), PV, PE
 uint constexpr nstats = 6;
@@ -98,7 +101,7 @@ public:
   bool dycore_tracer_pos[ntracers_dycore + GPU_PAD];
   bool acoustic_balance;
   bool uniform_vertical;
-  real entropicvar_diffusion_coeff;
+  real scalar_diffusion_coeff;
   real velocity_diffusion_coeff;
   // forces reference state to be in perfect hydrostatic balance by subtracting
   // the hydrostatic balance equation evaluated at the reference state in

--- a/dynamics/spam/src/extrudedmodel-common.h
+++ b/dynamics/spam/src/extrudedmodel-common.h
@@ -102,6 +102,7 @@ public:
   bool acoustic_balance;
   bool uniform_vertical;
   real scalar_diffusion_coeff;
+  real scalar_diffusion_subtract_refstate;
   real velocity_diffusion_coeff;
   // forces reference state to be in perfect hydrostatic balance by subtracting
   // the hydrostatic balance equation evaluated at the reference state in

--- a/dynamics/spam/src/hamiltonians/variableset.h
+++ b/dynamics/spam/src/hamiltonians/variableset.h
@@ -496,10 +496,12 @@ void convert_dynamics_to_coupler_densities(
           } else {
             real p = varset.get_pres(prog_vars.fields_arr[DENSVAR].data, k, j,
                                      i, dks, djs, dis, n);
-            real refqv = varset.get_qv(varset.reference_state.dens.data, k, dks, n);
-            real refqd = varset.get_qd(varset.reference_state.dens.data, k, dks, n);
-            temp = thermo.compute_T_from_p(p, entropic_var, refqd, refqv, ql, 
-                                           qi);
+            real refqv =
+                varset.get_qv(varset.reference_state.dens.data, k, dks, n);
+            real refqd =
+                varset.get_qd(varset.reference_state.dens.data, k, dks, n);
+            temp =
+                thermo.compute_T_from_p(p, entropic_var, refqd, refqv, ql, qi);
           }
 
           dm_temp(k, j, i, n) = temp;
@@ -691,10 +693,12 @@ void convert_coupler_to_dynamics_densities(
           } else {
             real p = varset.get_pres(prog_vars.fields_arr[DENSVAR].data, k, j,
                                      i, dks, djs, dis, n);
-            real refqv = varset.get_qv(varset.reference_state.dens.data, k, dks, n);
-            real refqd = varset.get_qd(varset.reference_state.dens.data, k, dks, n);
-            entropic_var = thermo.compute_entropic_var_from_p_T(
-                p, temp, refqd, refqv, ql, qi);
+            real refqv =
+                varset.get_qv(varset.reference_state.dens.data, k, dks, n);
+            real refqd =
+                varset.get_qd(varset.reference_state.dens.data, k, dks, n);
+            entropic_var = thermo.compute_entropic_var_from_p_T(p, temp, refqd,
+                                                                refqv, ql, qi);
           }
 
           varset.set_entropic_density(

--- a/dynamics/spam/src/hamiltonians/variableset.h
+++ b/dynamics/spam/src/hamiltonians/variableset.h
@@ -21,6 +21,7 @@ struct VS_SWE {
   static constexpr uint ndensity_dycore = 1;
   static constexpr uint ndensity_dycore_prognostic = ndensity_dycore;
   static constexpr uint ndensity_dycore_active = ndensity_dycore;
+  static constexpr uint ndensity_dycore_diffused = 0;
 
   static constexpr uint ntracers_dycore_active = 0;
 
@@ -36,6 +37,7 @@ struct VS_TSWE {
   static constexpr uint ndensity_dycore = 2;
   static constexpr uint ndensity_dycore_prognostic = 2;
   static constexpr uint ndensity_dycore_active = 2;
+  static constexpr uint ndensity_dycore_diffused = 1;
 
   static constexpr uint ntracers_dycore_active = 0;
 
@@ -51,6 +53,7 @@ struct VS_CE {
   static constexpr uint ndensity_dycore = 2;
   static constexpr uint ndensity_dycore_prognostic = ndensity_dycore;
   static constexpr uint ndensity_dycore_active = ndensity_dycore;
+  static constexpr uint ndensity_dycore_diffused = 1;
 
   static constexpr uint ntracers_dycore_active = 0;
 
@@ -66,6 +69,7 @@ struct VS_AN {
   static constexpr uint ndensity_dycore = 2;
   static constexpr uint ndensity_dycore_prognostic = 1;
   static constexpr uint ndensity_dycore_active = ndensity_dycore;
+  static constexpr uint ndensity_dycore_diffused = 1;
 
   static constexpr uint ntracers_dycore_active = 0;
 
@@ -83,6 +87,7 @@ struct VS_MAN {
   static constexpr uint ndensity_dycore = 2;
   static constexpr uint ndensity_dycore_prognostic = 1;
   static constexpr uint ndensity_dycore_active = ndensity_dycore;
+  static constexpr uint ndensity_dycore_diffused = 1;
 
   static constexpr uint ntracers_dycore_active = 0;
 
@@ -104,6 +109,7 @@ struct VS_MCE_rho {
   static constexpr uint ndensity_dycore = 2;
   static constexpr uint ndensity_dycore_prognostic = ndensity_dycore;
   static constexpr uint ndensity_dycore_active = ndensity_dycore;
+  static constexpr uint ndensity_dycore_diffused = 1;
 
   static constexpr uint ntracers_dycore_active = 0;
 
@@ -135,6 +141,7 @@ template <class T> class VariableSetBase : public T {
 public:
   using T::ndensity_dycore;
   using T::ndensity_dycore_active;
+  using T::ndensity_dycore_diffused;
   using T::ndensity_dycore_prognostic;
 
   using T::ntracers_dycore_active;
@@ -149,6 +156,8 @@ public:
       ndensity_dycore_prognostic + ntracers_dycore;
   static constexpr uint ndensity_active =
       ndensity_dycore_active + ntracers_dycore_active + ntracers_physics_active;
+  // TODO: Add tracers and physics
+  static constexpr uint ndensity_diffused = ndensity_dycore_diffused;
   static constexpr uint ndensity_prognostic =
       ndensity_dycore_prognostic + ntracers_dycore + ntracers_physics;
 
@@ -158,9 +167,12 @@ public:
       dens_pos; // Whether each density is positive-definite
   SArray<bool, 1, ndensity> dens_active; // Whether each density is active
   SArray<bool, 1, ndensity>
-      dens_prognostic; // Whether each density is prognostic
+      dens_prognostic;                     // Whether each density is prognostic
+  SArray<bool, 1, ndensity> dens_diffused; // Whether each density is diffused
   SArray<int, 1, ndensity_active>
       active_dens_ids; // indices of active densities
+  SArray<int, 1, ndensity_diffused>
+      diffused_dens_ids; // indices of diffused densities
 
   int dm_id_vap = std::numeric_limits<int>::min();
   int dm_id_liq = std::numeric_limits<int>::min();
@@ -283,6 +295,15 @@ public:
       }
     }
 
+    // get indicies of diffused densities
+    int diffused_i = 0;
+    for (int i = 0; i < ndensity; ++i) {
+      if (varset.dens_diffused(i)) {
+        varset.diffused_dens_ids(diffused_i) = i;
+        diffused_i++;
+      }
+    }
+
     for (int i = ndensity_dycore_prognostic; i < ndensity_nophysics; i++) {
       varset.dens_name[i] =
           "Tracer" + std::to_string(i - ndensity_dycore_prognostic);
@@ -303,6 +324,10 @@ public:
         ss << std::setw(10)
            << ((varset.dens_prognostic(i) && varset.dens_pos(i)) ? "positive"
                                                                  : "");
+        ss << std::setw(10)
+           << ((varset.dens_prognostic(i) && varset.dens_diffused(i))
+                   ? "diffused"
+                   : "");
 
         serial_print(ss.str(), params.masterproc);
       }
@@ -854,6 +879,7 @@ void VariableSetBase<VS_SWE>::initialize(PamCoupler &coupler,
   dens_desc[dens_id_mass] = "fluid height";
   dens_prognostic(dens_id_mass) = true;
   dens_active(dens_id_mass) = true;
+  dens_diffused(dens_id_mass) = false;
 
   VariableSetBase::initialize(*this, coupler, params, thermodynamics, refstate,
                               primal_geom, dual_geom, verbose);
@@ -883,6 +909,7 @@ void VariableSetBase<VS_TSWE>::initialize(PamCoupler &coupler,
   dens_prognostic(dens_id_mass) = true;
   dens_active(dens_id_mass) = true;
   dens_pos(dens_id_mass) = false;
+  dens_diffused(dens_id_mass) = false;
 
   dens_id_entr = 1;
   active_id_entr = 1;
@@ -891,6 +918,7 @@ void VariableSetBase<VS_TSWE>::initialize(PamCoupler &coupler,
   dens_prognostic(dens_id_entr) = true;
   dens_active(dens_id_entr) = true;
   dens_pos(dens_id_entr) = false;
+  dens_diffused(dens_id_entr) = true;
 
   VariableSetBase::initialize(*this, coupler, params, thermodynamics, refstate,
                               primal_geom, dual_geom, verbose);
@@ -914,6 +942,7 @@ void VariableSetBase<VS_CE>::initialize(PamCoupler &coupler,
   dens_prognostic(dens_id_mass) = true;
   dens_active(dens_id_mass) = true;
   dens_pos(dens_id_mass) = false;
+  dens_diffused(dens_id_mass) = false;
 
   dens_id_entr = 1;
   active_id_entr = 1;
@@ -922,6 +951,7 @@ void VariableSetBase<VS_CE>::initialize(PamCoupler &coupler,
   dens_prognostic(dens_id_entr) = true;
   dens_active(dens_id_entr) = true;
   dens_pos(dens_id_entr) = false;
+  dens_diffused(dens_id_entr) = true;
 
   VariableSetBase::initialize(*this, coupler, params, thermodynamics, refstate,
                               primal_geom, dual_geom, verbose);
@@ -985,6 +1015,7 @@ void VariableSetBase<VS_AN>::initialize(PamCoupler &coupler,
   dens_prognostic(dens_id_entr) = true;
   dens_active(dens_id_entr) = true;
   dens_pos(dens_id_entr) = false;
+  dens_diffused(dens_id_entr) = true;
 
   //  mass density is always stored last for anelastic
   //  this is to make prognostic densities a continuous subset of all densities
@@ -994,6 +1025,7 @@ void VariableSetBase<VS_AN>::initialize(PamCoupler &coupler,
   dens_desc[dens_id_mass] = "fluid density";
   dens_prognostic(dens_id_mass) = false;
   dens_active(dens_id_mass) = true;
+  dens_diffused(dens_id_mass) = false;
 
   VariableSetBase::initialize(*this, coupler, params, thermodynamics, refstate,
                               primal_geom, dual_geom, verbose);
@@ -1089,6 +1121,7 @@ void VariableSetBase<VS_MAN>::initialize(PamCoupler &coupler,
   dens_prognostic(dens_id_entr) = true;
   dens_active(dens_id_entr) = true;
   dens_pos(dens_id_entr) = false;
+  dens_diffused(dens_id_entr) = true;
 
   //  mass density is always stored last for anelastic
   //  this is to make prognostic densities a continuous subset of all densities
@@ -1098,6 +1131,7 @@ void VariableSetBase<VS_MAN>::initialize(PamCoupler &coupler,
   dens_desc[dens_id_mass] = "fluid density";
   dens_prognostic(dens_id_mass) = false;
   dens_active(dens_id_mass) = true;
+  dens_diffused(dens_id_mass) = false;
 
   VariableSetBase::initialize(*this, coupler, params, thermodynamics, refstate,
                               primal_geom, dual_geom, verbose);
@@ -1289,6 +1323,7 @@ void VariableSetBase<VS_MCE_rho>::initialize(
   dens_prognostic(dens_id_mass) = true;
   dens_active(dens_id_mass) = true;
   dens_pos(dens_id_mass) = false;
+  dens_diffused(dens_id_mass) = false;
 
   dens_id_entr = 1;
   active_id_entr = 1;
@@ -1297,6 +1332,7 @@ void VariableSetBase<VS_MCE_rho>::initialize(
   dens_prognostic(dens_id_entr) = true;
   dens_active(dens_id_entr) = true;
   dens_pos(dens_id_entr) = false;
+  dens_diffused(dens_id_entr) = true;
 
   VariableSetBase::initialize(*this, coupler, params, thermodynamics, refstate,
                               primal_geom, dual_geom, verbose);
@@ -1465,6 +1501,7 @@ void VariableSetBase<VS_MCE_rhod>::initialize(
   dens_prognostic(dens_id_mass) = true;
   dens_active(dens_id_mass) = true;
   dens_pos(dens_id_mass) = false;
+  dens_diffused(dens_id_mass) = false;
 
   dens_id_entr = 1;
   active_id_entr = 1;
@@ -1473,6 +1510,7 @@ void VariableSetBase<VS_MCE_rhod>::initialize(
   dens_prognostic(dens_id_entr) = true;
   dens_active(dens_id_entr) = true;
   dens_pos(dens_id_entr) = false;
+  dens_diffused(dens_id_entr) = true;
 
   VariableSetBase::initialize(*this, coupler, params, thermodynamics, refstate,
                               primal_geom, dual_geom, verbose);

--- a/dynamics/spam/src/models/extrudedmodel.h
+++ b/dynamics/spam/src/models/extrudedmodel.h
@@ -303,12 +303,12 @@ struct AnelasticPressureSolver {
           }
           tri_u(k, j, i, n) = 0;
 
-          const real h_k =
-              rho_di(0, k + dks, n) * H01_coeff(primal_geometry, dual_geometry,
-                                                pis, pjs, pks, i, j, k, n);
+          const real h_k = rho_di(0, k + dks, n) *
+                           H01_diagonal(primal_geometry, dual_geometry, pis,
+                                        pjs, pks, i, j, k, n);
           const real h_kp1 = rho_di(0, k + dks + 1, n) *
-                             H01_coeff(primal_geometry, dual_geometry, pis, pjs,
-                                       pks, i, j, k + 1, n);
+                             H01_diagonal(primal_geometry, dual_geometry, pis,
+                                          pjs, pks, i, j, k + 1, n);
 
           tri_u(k, j, i, n) += h_kp1;
           tri_l(k, j, i, n) += h_k;
@@ -2966,14 +2966,14 @@ public:
               n_cells_x, n_cells_y, dual_topology.ni);
 
           real gamma_fac_kp2 = rho_di(0, k + dks + 2, n) *
-                               H01_coeff(primal_geometry, dual_geometry, pis,
-                                         pjs, pks, i, j, k + 2, n);
+                               H01_diagonal(primal_geometry, dual_geometry, pis,
+                                            pjs, pks, i, j, k + 2, n);
           real gamma_fac_kp1 = rho_di(0, k + dks + 1, n) *
-                               H01_coeff(primal_geometry, dual_geometry, pis,
-                                         pjs, pks, i, j, k + 1, n);
-          real gamma_fac_k =
-              rho_di(0, k + dks, n) * H01_coeff(primal_geometry, dual_geometry,
-                                                pis, pjs, pks, i, j, k, n);
+                               H01_diagonal(primal_geometry, dual_geometry, pis,
+                                            pjs, pks, i, j, k + 1, n);
+          real gamma_fac_k = rho_di(0, k + dks, n) *
+                             H01_diagonal(primal_geometry, dual_geometry, pis,
+                                          pjs, pks, i, j, k, n);
 
           tri_u(k, j, i, n) = 0;
           tri_d(k, j, i, n) = 1;
@@ -3011,14 +3011,14 @@ public:
               n_cells_x, n_cells_y, dual_topology.ni);
 
           real gamma_fac_kp2 = rho_di(0, k + dks + 2, n) *
-                               H01_coeff(primal_geometry, dual_geometry, pis,
-                                         pjs, pks, i, j, k + 2, n);
+                               H01_diagonal(primal_geometry, dual_geometry, pis,
+                                            pjs, pks, i, j, k + 2, n);
           real gamma_fac_kp1 = rho_di(0, k + dks + 1, n) *
-                               H01_coeff(primal_geometry, dual_geometry, pis,
-                                         pjs, pks, i, j, k + 1, n);
-          real gamma_fac_k =
-              rho_di(0, k + dks, n) * H01_coeff(primal_geometry, dual_geometry,
-                                                pis, pjs, pks, i, j, k, n);
+                               H01_diagonal(primal_geometry, dual_geometry, pis,
+                                            pjs, pks, i, j, k + 1, n);
+          real gamma_fac_k = rho_di(0, k + dks, n) *
+                             H01_diagonal(primal_geometry, dual_geometry, pis,
+                                          pjs, pks, i, j, k, n);
 
           SArray<real, 1, ndims> fH1_kp1_a;
           SArray<real, 1, ndims> fH1_k_a;
@@ -3291,11 +3291,11 @@ public:
           }
 
           real gamma_fac_kp1 = rho_di(0, k + dks + 1, n) *
-                               H01_coeff(primal_geometry, dual_geometry, pis,
-                                         pjs, pks, i, j, k + 1, n);
-          real gamma_fac_k =
-              rho_di(0, k + dks, n) * H01_coeff(primal_geometry, dual_geometry,
-                                                pis, pjs, pks, i, j, k, n);
+                               H01_diagonal(primal_geometry, dual_geometry, pis,
+                                            pjs, pks, i, j, k + 1, n);
+          real gamma_fac_k = rho_di(0, k + dks, n) *
+                             H01_diagonal(primal_geometry, dual_geometry, pis,
+                                          pjs, pks, i, j, k, n);
 
           complex_vrhs(k, j, i, n) *= complex_vcoeff(0, k, j, i, n);
           for (int d1 = 0; d1 < VS::ndensity_dycore; ++d1) {

--- a/dynamics/spam/src/models/extrudedmodel.h
+++ b/dynamics/spam/src/models/extrudedmodel.h
@@ -1293,7 +1293,7 @@ public:
     int dks = dual_topology.ks;
 
     YAKL_SCOPE(varset, this->equations->varset);
-    YAKL_SCOPE(refdens, this->equations->reference_state.dens.data);
+    YAKL_SCOPE(q_di, this->equations->reference_state.q_di.data);
     YAKL_SCOPE(primal_geometry, this->primal_geometry);
     YAKL_SCOPE(dual_geometry, this->dual_geometry);
 
@@ -1307,11 +1307,11 @@ public:
 
           for (int d = 0; d < VS::ndensity_diffused; ++d) {
             int dens_id = varset.diffused_dens_ids(d);
-            real dens0 = densvar(dens_id, k + pks, j + pjs, i + pis, n);
-            if (subtract_refstate) {
-              dens0 -= refdens(d, k + dks, n);
-            }
+            real dens0 = densvar(dens_id, k + dks, j + djs, i + dis, n);
             dens0 /= total_dens;
+            if (subtract_refstate) {
+              dens0 -= q_di(dens_id, k + dks, n);
+            }
             dens0var(d, k + pks, j + pjs, i + pis, n) = dens0;
           }
         });
@@ -1446,7 +1446,7 @@ public:
 
     parallel_for(
         "Velocity diffusion 4",
-        SimpleBounds<4>(primal_topology.nl, primal_topology.n_cells_y,
+        SimpleBounds<4>(primal_topology.ni, primal_topology.n_cells_y,
                         primal_topology.n_cells_x, primal_topology.nens),
         YAKL_LAMBDA(int k, int j, int i, int n) {
           SArray<real, 1, 1> Dhorz;

--- a/dynamics/spam/src/operators/hodge_star.h
+++ b/dynamics/spam/src/operators/hodge_star.h
@@ -26,40 +26,49 @@ void YAKL_INLINE H0bar(SArray<real, 1, ndofs> &var,
   }
 }
 
-void YAKL_INLINE H1(SArray<real, 1, ndims> &var,
-                    SArray<real, 2, ndims, 1> const &velocity,
+template <uint ndofs>
+void YAKL_INLINE H1(SArray<real, 2, ndofs, ndims> &var,
+                    SArray<real, 3, ndofs, ndims, 1> const &velocity,
                     SArray<real, 1, ndims> const &H1geom) {
 
-  for (int d = 0; d < ndims; d++) {
-    var(d) = velocity(d, 0);
-    var(d) *= H1geom(d);
+  for (int l = 0; l < ndofs; l++) {
+    for (int d = 0; d < ndims; d++) {
+      var(l, d) = velocity(l, d, 0);
+      var(l, d) *= H1geom(d);
+    }
   }
 }
 
-void YAKL_INLINE H1(SArray<real, 1, ndims> &var,
-                    SArray<real, 2, ndims, 3> const &velocity,
+template <uint ndofs>
+void YAKL_INLINE H1(SArray<real, 2, ndofs, ndims> &var,
+                    SArray<real, 3, ndofs, ndims, 3> const &velocity,
                     SArray<real, 1, ndims> const &H1geom) {
 
-  for (int d = 0; d < ndims; d++) {
-    var(d) = -1.0_fp / 24.0_fp * velocity(d, 0) +
-             26.0_fp / 24.0_fp * velocity(d, 1) -
-             1.0_fp / 24.0_fp * velocity(d, 2);
-    var(d) *= H1geom(d);
+  for (int l = 0; l < ndofs; l++) {
+    for (int d = 0; d < ndims; d++) {
+      var(l, d) = -1.0_fp / 24.0_fp * velocity(l, d, 0) +
+                  26.0_fp / 24.0_fp * velocity(l, d, 1) -
+                  1.0_fp / 24.0_fp * velocity(l, d, 2);
+      var(l, d) *= H1geom(d);
+    }
   }
 }
 
-void YAKL_INLINE H1(SArray<real, 1, ndims> &var,
-                    SArray<real, 2, ndims, 5> const &velocity,
+template <uint ndofs>
+void YAKL_INLINE H1(SArray<real, 2, ndofs, ndims> &var,
+                    SArray<real, 3, ndofs, ndims, 5> const &velocity,
                     SArray<real, 1, ndims> const &H1geom) {
 
-  for (int d = 0; d < ndims; d++) {
-    var(d) = 9.0_fp / 1920.0_fp * velocity(d, 0) -
-             116.0_fp / 1920.0_fp * velocity(d, 1) +
-             2134.0_fp / 1920.0_fp * velocity(d, 2) -
-             116.0_fp / 1920.0_fp * velocity(d, 3) +
-             9.0_fp / 1920.0_fp * velocity(d, 4);
+  for (int l = 0; l < ndofs; l++) {
+    for (int d = 0; d < ndims; d++) {
+      var(l, d) = 9.0_fp / 1920.0_fp * velocity(l, d, 0) -
+                  116.0_fp / 1920.0_fp * velocity(l, d, 1) +
+                  2134.0_fp / 1920.0_fp * velocity(l, d, 2) -
+                  116.0_fp / 1920.0_fp * velocity(l, d, 3) +
+                  9.0_fp / 1920.0_fp * velocity(l, d, 4);
 
-    var(d) *= H1geom(d);
+      var(l, d) *= H1geom(d);
+    }
   }
 }
 

--- a/dynamics/spam/src/operators/hodge_star_extruded.h
+++ b/dynamics/spam/src/operators/hodge_star_extruded.h
@@ -259,7 +259,7 @@ void YAKL_INLINE Hnm11_diagonal(SArray<real, 1, ndims> &Hnm11diag,
                                 const Geometry<Twisted> &dgeom, int is, int js,
                                 int ks, int i, int j, int k, int n) {
   for (int d = 0; d < ndims; d++) {
-    Hnm11diag(d) = dgeom.get_area_10entity(d, k + ks, j + js, i + is, n) /
+    Hnm11diag(d) = -dgeom.get_area_10entity(d, k + ks, j + js, i + is, n) /
                    pgeom.get_area_nm11entity(d, k - 1 + ks, j + js, i + is, n);
   }
 }
@@ -273,6 +273,9 @@ void YAKL_INLINE compute_Hnm11(SArray<real, 1, ndims> &u, const real5d &vvar,
 
   SArray<real, 1, ndims> Hnm11geom;
   Hnm11_diagonal(Hnm11geom, pgeom, dgeom, is, js, ks, i, j, k, n);
+  for (int d = 0; d < ndims; d++) {
+    Hnm11geom(d) *= -1;
+  }
 
   for (int p = 0; p < ord - 1; p++) {
     for (int d = 0; d < ndims; d++) {
@@ -355,7 +358,7 @@ void YAKL_INLINE Hnm11bar_diagonal(SArray<real, 1, ndims> &Hnm11bardiag,
                                    const Geometry<Twisted> &dgeom, int is,
                                    int js, int ks, int i, int j, int k, int n) {
   for (int d = 0; d < ndims; d++) {
-    Hnm11bardiag(d) = pgeom.get_area_10entity(d, k + ks, j + js, i + is, n) /
+    Hnm11bardiag(d) = -pgeom.get_area_10entity(d, k + ks, j + js, i + is, n) /
                       dgeom.get_area_nm11entity(d, k + ks, j + js, i + is, n);
   }
 }
@@ -369,6 +372,9 @@ void YAKL_INLINE compute_Hnm11bar(SArray<real, 1, ndims> &u, const real5d &vvar,
   SArray<real, 1, ndims> Hnm11bargeom;
 
   Hnm11bar_diagonal(Hnm11bargeom, pgeom, dgeom, is, js, ks, i, j, k, n);
+  for (int d = 0; d < ndims; d++) {
+    Hnm11bargeom(d) *= -1;
+  }
 
   for (int p = 0; p < ord - 1; p++) {
     for (int d = 0; d < ndims; d++) {

--- a/standalone/mmf_simplified/inputs/pamc_idealized/pamc_input_extruded_densitycurrent.yaml
+++ b/standalone/mmf_simplified/inputs/pamc_idealized/pamc_input_extruded_densitycurrent.yaml
@@ -4,7 +4,7 @@ verbose : true
 # Simulation time in seconds
 sim_time : 900
 
-entropicvar_diffusion_coeff : 75
+scalar_diffusion_coeff : 75
 velocity_diffusion_coeff : 75
 
 # Number of cells to use


### PR DESCRIPTION
This PR:
- Generalizes the code for entropic variable diffusion to allow diffusing other scalars
- Add an option to subtract the reference state before applying diffusion
- Adds code to make it easy to apply diagonal Hodge stars in place
- Reduces the number of diffusion kernels using the above 

@celdredsandia This might be helpful in your hyper-diffusion work.