### PR TITLE
Improve CI

### DIFF
--- a/standalone/machines/ci/macos-clang.env
+++ b/standalone/machines/ci/macos-clang.env
@@ -14,7 +14,7 @@ export OMPI_CC=clang
 export OMPI_CXX=clang++
 export OMPI_FC=gfortran-12
 
-export YAKL_CXX_FLAGS="-DHAVE_MPI -O2 -I`nc-config --includedir`"
+export YAKL_CXX_FLAGS="-g -ftrivial-auto-var-init=pattern -DHAVE_MPI -O2 -I`nc-config --includedir`"
 export YAKL_F90_FLAGS="-O2 -ffree-line-length-none"
 export PAM_LINK_FLAGS="-L`nc-config --libdir` -lnetcdf"
 export PAM_NLEV=50

--- a/standalone/machines/ci/ubuntu-clang.env
+++ b/standalone/machines/ci/ubuntu-clang.env
@@ -14,7 +14,7 @@ export OMPI_CC=clang
 export OMPI_CXX=clang++
 export OMPI_FC=gfortran
 
-export YAKL_CXX_FLAGS="-DHAVE_MPI -O2 -I`nc-config --includedir`"
+export YAKL_CXX_FLAGS="-g -ftrivial-auto-var-init=pattern -DHAVE_MPI -O2 -I`nc-config --includedir`"
 export YAKL_F90_FLAGS="-O2 -ffree-line-length-none"
 export PAM_LINK_FLAGS="-L`nc-config --libdir` -lnetcdf"
 export PAM_NLEV=50

--- a/standalone/machines/ci/ubuntu-gcc.env
+++ b/standalone/machines/ci/ubuntu-gcc.env
@@ -10,11 +10,11 @@ export CC=mpicc
 export CXX=mpic++
 export FC=mpifort
 
-export OMPI_CC=gcc
-export OMPI_CXX=g++
-export OMPI_FC=gfortran
+export OMPI_CC=gcc-12
+export OMPI_CXX=g++-12
+export OMPI_FC=gfortran-12
 
-export YAKL_CXX_FLAGS="-DHAVE_MPI -O2 -I`nc-config --includedir`"
+export YAKL_CXX_FLAGS="-g -ftrivial-auto-var-init=pattern -DHAVE_MPI -O2 -I`nc-config --includedir`"
 export YAKL_F90_FLAGS="-O2 -ffree-line-length-none"
 export PAM_LINK_FLAGS="-L`nc-config --libdir` -lnetcdf"
 export PAM_NLEV=50


### PR DESCRIPTION
Adds `ftrivial-auto-var-init=pattern` compiler flag to the CI to improve the chance of catching uninitialized memory bugs.