### PR TITLE
[PAM-C] Add 3D supercell test case

### DIFF
--- a/dynamics/spam/CMakeLists.txt
+++ b/dynamics/spam/CMakeLists.txt
@@ -17,6 +17,9 @@ target_include_directories(dycore INTERFACE src/grids)
 target_include_directories(dycore INTERFACE src/io)
 target_include_directories(dycore INTERFACE src/core)
 
+set(PAMC_NDIMS "1" CACHE STRING "PAM-C ndims")
+target_compile_definitions(dycore INTERFACE -DPAMC_NDIMS=${PAMC_NDIMS})
+
 if ("${PAMC_MODEL}" STREQUAL "layermodel")
   target_compile_definitions(dycore INTERFACE -DPAMC_LAYER)
 endif()

--- a/dynamics/spam/Dycore.h
+++ b/dynamics/spam/Dycore.h
@@ -283,9 +283,9 @@ public:
     }
     prevstep += params.crm_per_phys;
 
-    //if (!time_integrator->is_ssp) {
-      tendencies.remove_negative_densities(prognostic_vars);
-    //}
+    if (params.clip_negative_densities) {
+      tendencies.clip_negative_densities(prognostic_vars);
+    }
 
     // convert dynamics state to Coupler state
     tendencies.convert_dynamics_to_coupler_state(

--- a/dynamics/spam/Dycore.h
+++ b/dynamics/spam/Dycore.h
@@ -283,9 +283,9 @@ public:
     }
     prevstep += params.crm_per_phys;
 
-    if (!time_integrator->is_ssp) {
+    //if (!time_integrator->is_ssp) {
       tendencies.remove_negative_densities(prognostic_vars);
-    }
+    //}
 
     // convert dynamics state to Coupler state
     tendencies.convert_dynamics_to_coupler_state(

--- a/dynamics/spam/src/core/params.h
+++ b/dynamics/spam/src/core/params.h
@@ -41,6 +41,7 @@ public:
   // solve a system to exactly invert the velocity averaging done
   // during conversion to coupler state when coupling winds
   bool couple_wind_exact_inverse = false;
+  bool clip_negative_densities = true;
 };
 
 void readParamsFile(std::string inFile, Parameters &params, Parallel &par,
@@ -77,6 +78,9 @@ void readParamsFile(std::string inFile, Parameters &params, Parallel &par,
   params.couple_wind = config["couple_wind"].as<bool>(true);
   params.couple_wind_exact_inverse =
       config["couple_wind_exact_inverse"].as<bool>(false);
+
+  params.clip_negative_densities =
+      config["clip_negative_densities"].as<bool>(true);
 
   // ADD A CHECK HERE THAT TOTAL TIME IS EXACTLY DIVISIBLE BY STAT_FREQ
   if (params.stat_freq >= 0.) {

--- a/dynamics/spam/src/extrudedmodel-common.h
+++ b/dynamics/spam/src/extrudedmodel-common.h
@@ -108,6 +108,7 @@ public:
   real velocity_div_horiz_diffusion_coeff;
   real velocity_div_vert_diffusion_coeff;
   bool scalar_diffusion_subtract_refstate;
+  bool velocity_diffusion_subtract_refstate;
 
   // forces reference state to be in perfect hydrostatic balance by subtracting
   // the hydrostatic balance equation evaluated at the reference state in

--- a/dynamics/spam/src/extrudedmodel-common.h
+++ b/dynamics/spam/src/extrudedmodel-common.h
@@ -10,7 +10,7 @@ uint constexpr ntracers_dycore = 0;
 //////////////////////////////////////////////////////////////////////////////
 
 // Number of Dimensions
-uint constexpr ndims = 2;
+uint constexpr ndims = PAMC_NDIMS;
 } // namespace pamc
 
 #include "params.h"

--- a/dynamics/spam/src/extrudedmodel-common.h
+++ b/dynamics/spam/src/extrudedmodel-common.h
@@ -10,7 +10,7 @@ uint constexpr ntracers_dycore = 0;
 //////////////////////////////////////////////////////////////////////////////
 
 // Number of Dimensions
-uint constexpr ndims = 1;
+uint constexpr ndims = 2;
 } // namespace pamc
 
 #include "params.h"

--- a/dynamics/spam/src/grids/geometry.h
+++ b/dynamics/spam/src/grids/geometry.h
@@ -234,6 +234,10 @@ public:
   template <class F>
   void set_profile_00form_values(F initial_value_function, Profile &prof,
                                  int ndof) const;
+
+  template <class F>
+  void set_profile_10form_values(F initial_value_function, Profile &prof,
+                                 int ndof) const;
   template <class F>
   void set_profile_n1form_values(F initial_value_function, Profile &prof,
                                  int ndof) const;
@@ -1110,6 +1114,81 @@ void Geometry<T>::set_profile_00form_values(F initial_value_function,
         get_00form_quad_pts_wts(k, j, i, n, quad_pts_phys, quad_wts_phys);
         prof.data(ndof, k + ks, n) =
             initial_value_function(quad_pts_phys(0).z) * quad_wts_phys(0);
+      });
+}
+
+template <class T>
+template <class F>
+void Geometry<T>::set_profile_10form_values(F initial_value_function,
+                                            Profile &prof, int ndof) const {
+  int ks = this->topology.ks;
+
+  int yedge_offset = std::numeric_limits<int>::min();
+  int xedge_offset = std::numeric_limits<int>::min();
+
+  if (ndims > 1) {
+    // twisted edges
+    yedge_offset = 0;
+    xedge_offset = prof.ndofs;
+
+    // compared to twisted edges in 2D, straight edges are stored x/y (V, -U)
+    // instead of y/x
+    if (straight) {
+      yedge_offset = prof.ndofs;
+      xedge_offset = 0;
+    }
+  } else {
+    xedge_offset = 0;
+  }
+
+  parallel_for(
+      "Set 10 form values",
+      SimpleBounds<2>(this->topology.ni, this->topology.nens),
+      YAKL_CLASS_LAMBDA(int k, int n) {
+        int i = 0;
+        int j = 0;
+        SArray<CoordsXYZ, 1, ic_quad_pts_x> x_edge_quad_pts_phys;
+        SArray<real, 1, ic_quad_pts_x> x_edge_quad_wts_phys;
+        SArray<VecXYZ, 1, ic_quad_pts_x> x_edge_line_vec;
+
+        SArray<CoordsXYZ, 1, ic_quad_pts_y> y_edge_quad_pts_phys;
+        SArray<real, 1, ic_quad_pts_y> y_edge_quad_wts_phys;
+        SArray<VecXYZ, 1, ic_quad_pts_y> y_edge_line_vec;
+
+        get_10form_quad_pts_wts(k, j, i, n, x_edge_quad_pts_phys,
+                                x_edge_quad_wts_phys, y_edge_quad_pts_phys,
+                                y_edge_quad_wts_phys);
+        get_10edge_tangents(k, j, i, n, x_edge_line_vec, y_edge_line_vec);
+
+        // x edge
+        real x_tempval = 0.0_fp;
+        for (int nqx = 0; nqx < ic_quad_pts_x; nqx++) {
+          auto initval = initial_value_function(x_edge_quad_pts_phys(nqx).x,
+                                                x_edge_quad_pts_phys(nqx).y,
+                                                x_edge_quad_pts_phys(nqx).z);
+
+          x_tempval += (initval.u * x_edge_line_vec(nqx).u +
+                        initval.v * x_edge_line_vec(nqx).v +
+                        initval.w * x_edge_line_vec(nqx).w) *
+                       x_edge_quad_wts_phys(nqx);
+        }
+        prof.data(ndof + xedge_offset, k + ks, n) = x_tempval;
+
+        // y edge
+        if (ndims > 1) {
+          real y_tempval = 0.0_fp;
+          for (int nqy = 0; nqy < ic_quad_pts_y; nqy++) {
+            auto initval = initial_value_function(y_edge_quad_pts_phys(nqy).x,
+                                                  y_edge_quad_pts_phys(nqy).y,
+                                                  y_edge_quad_pts_phys(nqy).z);
+
+            y_tempval += (initval.u * y_edge_line_vec(nqy).u +
+                          initval.v * y_edge_line_vec(nqy).v +
+                          initval.w * y_edge_line_vec(nqy).w) *
+                         y_edge_quad_wts_phys(nqy);
+          }
+          prof.data(ndof + yedge_offset, k + ks, n) = y_tempval;
+        }
       });
 }
 

--- a/dynamics/spam/src/hamiltonians/refstate.h
+++ b/dynamics/spam/src/hamiltonians/refstate.h
@@ -16,6 +16,7 @@ struct ReferenceState_SWE {
   Profile rho_di;
   Profile rho_pi;
   Profile Nsq_pi;
+  Profile v;
   Profile B;
 #endif
   bool is_initialized = false;
@@ -30,6 +31,7 @@ struct ReferenceState_SWE {
     this->q_pi.initialize(primal_topology, "refq_pi", 0, 0, VS::ndensity);
     this->rho_di.initialize(dual_topology, "refrho_di", 0, 0, 1);
     this->q_di.initialize(dual_topology, "refq_di", 0, 0, VS::ndensity);
+    this->v.initialize(primal_topology, "ref v", 1, 0, 1);
     this->Nsq_pi.initialize(primal_topology, "refNsq_pi", 0, 0, 1);
 #endif
 
@@ -45,6 +47,7 @@ struct ReferenceState_Euler {
   Profile rho_di;
   Profile rho_pi;
   Profile Nsq_pi;
+  Profile v;
   Profile B;
   bool is_initialized = false;
 
@@ -59,6 +62,7 @@ struct ReferenceState_Euler {
     this->rho_di.initialize(dual_topology, "refrho_di", 0, 0, 1);
     this->q_di.initialize(dual_topology, "refq_di", 0, 0, VS::ndensity);
     this->Nsq_pi.initialize(primal_topology, "refNsq_pi", 0, 0, 1);
+    this->v.initialize(primal_topology, "ref v", 1, 0, 1);
     this->B.initialize(dual_topology, "ref B", 1, 1, VS::ndensity_active);
 
     this->is_initialized = true;

--- a/dynamics/spam/src/hamiltonians/variableset.h
+++ b/dynamics/spam/src/hamiltonians/variableset.h
@@ -222,7 +222,8 @@ public:
                          bool verbose = false) {
 
     if (T::couple && params.couple_wind_exact_inverse) {
-      if (primal_geom.topology.n_cells_x % 2 == 0) {
+      if (primal_geom.topology.n_cells_x % 2 == 0 ||
+          (ndims > 1 && primal_geom.topology.n_cells_y % 2 == 0)) {
         throw std::runtime_error(
             "The number of crm cells in the horizontal "
             "has to be odd when using the couple_wind_exact_inverse option");

--- a/dynamics/spam/src/hamiltonians/variableset.h
+++ b/dynamics/spam/src/hamiltonians/variableset.h
@@ -507,12 +507,12 @@ void convert_dynamics_to_coupler_densities(
                                djs, dis, n);
           }
 
-          if (T::compressible) {
+          //if (T::compressible) {
             dm_dens_dry(k, j, i, n) =
                 varset.get_dry_density(prog_vars.fields_arr[DENSVAR].data, k, j,
                                        i, dks, djs, dis, n) /
                 dual_geometry.get_area_n1entity(k + dks, j + djs, i + dis, n);
-          }
+          //}
 
           real temp;
           if (T::density_based) {

--- a/dynamics/spam/src/hamiltonians/variableset.h
+++ b/dynamics/spam/src/hamiltonians/variableset.h
@@ -221,7 +221,7 @@ public:
                          const Geometry<Twisted> &dual_geom,
                          bool verbose = false) {
 
-    if (T::couple && params.couple_wind_exact_inverse) {
+    if (T::couple && params.couple_wind && params.couple_wind_exact_inverse) {
       if (primal_geom.topology.n_cells_x % 2 == 0 ||
           (ndims > 1 && primal_geom.topology.n_cells_y % 2 == 0)) {
         throw std::runtime_error(

--- a/dynamics/spam/src/hamiltonians/variableset.h
+++ b/dynamics/spam/src/hamiltonians/variableset.h
@@ -528,7 +528,7 @@ void convert_dynamics_to_coupler_densities(
             real refqd =
                 varset.get_qd(varset.reference_state.dens.data, k, dks, n);
             temp =
-                thermo.compute_T_from_p(p, entropic_var, qd, qv, ql, qi);
+                thermo.compute_T_from_p(p, entropic_var, refqd, refqv, ql, qi);
           }
 
           dm_temp(k, j, i, n) = temp;
@@ -724,8 +724,8 @@ void convert_coupler_to_dynamics_densities(
                 varset.get_qv(varset.reference_state.dens.data, k, dks, n);
             real refqd =
                 varset.get_qd(varset.reference_state.dens.data, k, dks, n);
-            entropic_var = thermo.compute_entropic_var_from_p_T(p, temp, qd,
-                                                                qv, ql, qi);
+            entropic_var = thermo.compute_entropic_var_from_p_T(p, temp, refqd,
+                                                                refqv, ql, qi);
           }
 
           varset.set_entropic_density(
@@ -1252,8 +1252,9 @@ real YAKL_INLINE VariableSetBase<VS_MAN>::_water_dens(const real5d &densvar,
   real vap_dens = densvar(dens_id_vap, k + ks, j + js, i + is, n);
   real liq_dens = 0.0_fp;
   real ice_dens = 0.0_fp;
-  if (liq_found) { liq_dens = densvar(dens_id_liq, k + ks, j + js, i + is, n); }
-  if (ice_found) { ice_dens = densvar(dens_id_ice, k + ks, j + js, i + is, n); }
+  // if (liq_found) { liq_dens = densvar(dens_id_liq, k + ks, j + js, i + is,
+  // n); } if (ice_found) { ice_dens = densvar(dens_id_ice, k + ks, j + js, i +
+  // is, n); }
   return vap_dens + liq_dens + ice_dens;
 }
 
@@ -1264,8 +1265,8 @@ real YAKL_INLINE VariableSetBase<VS_MAN>::_water_dens(const real3d &densvar,
   real vap_dens = densvar(dens_id_vap, k + ks, n);
   real liq_dens = 0.0_fp;
   real ice_dens = 0.0_fp;
-  if (liq_found) { liq_dens = densvar(dens_id_liq, k + ks, n); }
-  if (ice_found) { ice_dens = densvar(dens_id_ice, k + ks, n); }
+  // if (liq_found) { liq_dens = densvar(dens_id_liq, k + ks, n); }
+  // if (ice_found) { ice_dens = densvar(dens_id_ice, k + ks, n); }
   return vap_dens + liq_dens + ice_dens;
 }
 

--- a/dynamics/spam/src/hamiltonians/variableset.h
+++ b/dynamics/spam/src/hamiltonians/variableset.h
@@ -528,7 +528,7 @@ void convert_dynamics_to_coupler_densities(
             real refqd =
                 varset.get_qd(varset.reference_state.dens.data, k, dks, n);
             temp =
-                thermo.compute_T_from_p(p, entropic_var, refqd, refqv, ql, qi);
+                thermo.compute_T_from_p(p, entropic_var, qd, qv, ql, qi);
           }
 
           dm_temp(k, j, i, n) = temp;
@@ -724,8 +724,8 @@ void convert_coupler_to_dynamics_densities(
                 varset.get_qv(varset.reference_state.dens.data, k, dks, n);
             real refqd =
                 varset.get_qd(varset.reference_state.dens.data, k, dks, n);
-            entropic_var = thermo.compute_entropic_var_from_p_T(p, temp, refqd,
-                                                                refqv, ql, qi);
+            entropic_var = thermo.compute_entropic_var_from_p_T(p, temp, qd,
+                                                                qv, ql, qi);
           }
 
           varset.set_entropic_density(
@@ -1252,9 +1252,8 @@ real YAKL_INLINE VariableSetBase<VS_MAN>::_water_dens(const real5d &densvar,
   real vap_dens = densvar(dens_id_vap, k + ks, j + js, i + is, n);
   real liq_dens = 0.0_fp;
   real ice_dens = 0.0_fp;
-  // if (liq_found) { liq_dens = densvar(dens_id_liq, k + ks, j + js, i + is,
-  // n); } if (ice_found) { ice_dens = densvar(dens_id_ice, k + ks, j + js, i +
-  // is, n); }
+  if (liq_found) { liq_dens = densvar(dens_id_liq, k + ks, j + js, i + is, n); }
+  if (ice_found) { ice_dens = densvar(dens_id_ice, k + ks, j + js, i + is, n); }
   return vap_dens + liq_dens + ice_dens;
 }
 
@@ -1265,8 +1264,8 @@ real YAKL_INLINE VariableSetBase<VS_MAN>::_water_dens(const real3d &densvar,
   real vap_dens = densvar(dens_id_vap, k + ks, n);
   real liq_dens = 0.0_fp;
   real ice_dens = 0.0_fp;
-  // if (liq_found) { liq_dens = densvar(dens_id_liq, k + ks, n); }
-  // if (ice_found) { ice_dens = densvar(dens_id_ice, k + ks, n); }
+  if (liq_found) { liq_dens = densvar(dens_id_liq, k + ks, n); }
+  if (ice_found) { ice_dens = densvar(dens_id_ice, k + ks, n); }
   return vap_dens + liq_dens + ice_dens;
 }
 

--- a/dynamics/spam/src/hamiltonians/variableset.h
+++ b/dynamics/spam/src/hamiltonians/variableset.h
@@ -157,7 +157,8 @@ public:
   static constexpr uint ndensity_active =
       ndensity_dycore_active + ntracers_dycore_active + ntracers_physics_active;
   // TODO: Add tracers and physics
-  static constexpr uint ndensity_diffused = ndensity_dycore_diffused;
+  static constexpr uint ndensity_diffused =
+      ndensity_dycore_diffused + ntracers_physics;
   static constexpr uint ndensity_prognostic =
       ndensity_dycore_prognostic + ntracers_dycore + ntracers_physics;
 
@@ -244,7 +245,7 @@ public:
       varset.dens_pos(tr + ndensity_nophysics) = positive;
       varset.dens_prognostic(tr + ndensity_nophysics) = true;
       varset.dens_active(tr + ndensity_nophysics) = false;
-      varset.dens_diffused(tr + ndensity_nophysics) = false;
+      varset.dens_diffused(tr + ndensity_nophysics) = true;
       if (tracer_names_loc[tr] == std::string("water_vapor")) {
         varset.dm_id_vap = tr;
         varset.dens_id_vap = ndensity_nophysics + tr;

--- a/dynamics/spam/src/models/extrudedmodel.h
+++ b/dynamics/spam/src/models/extrudedmodel.h
@@ -5975,6 +5975,10 @@ struct Supercell : TestCaseInit {
           refstate.dens.data(varset.dens_id_vap, k + dks, n) =
               rho * qv(k + pks, n) * dual_volume;
         });
+
+    primal_geometry.set_profile_10form_values(
+        YAKL_LAMBDA(real x, real y, real z) { return v_f(x, y, z); },
+        refstate.v, 0);
   }
 
   static void initialize(Equations *equations, FieldSet<nprognostic> &progvars,

--- a/dynamics/spam/src/models/extrudedmodel.h
+++ b/dynamics/spam/src/models/extrudedmodel.h
@@ -1378,9 +1378,11 @@ public:
                         dual_topology.n_cells_x, dual_topology.nens),
         YAKL_LAMBDA(int k, int j, int i, int n) {
           SArray<real, 1, VS::ndensity_diffused> hdiv;
-          compute_Dnm1bar<1>(hdiv, Fdiffvar, dis, djs, dks, i, j, k, n);
+          compute_Dnm1bar<VS::ndensity_diffused>(hdiv, Fdiffvar, dis, djs, dks,
+                                                 i, j, k, n);
           SArray<real, 1, VS::ndensity_diffused> vdiv;
-          compute_Dnm1bar_vert<1>(vdiv, FWdiffvar, dis, djs, dks, i, j, k, n);
+          compute_Dnm1bar_vert<VS::ndensity_diffused>(vdiv, FWdiffvar, dis, djs,
+                                                      dks, i, j, k, n);
 
           const real rho =
               varset.get_total_density(densvar, k, j, i, pks, pjs, pis, n);

--- a/dynamics/spam/src/models/extrudedmodel.h
+++ b/dynamics/spam/src/models/extrudedmodel.h
@@ -5196,7 +5196,12 @@ struct MoistRisingBubble : public RisingBubble<false> {
 
   static real YAKL_INLINE rhov_f(real x, real y, real z,
                                  const ThermoPotential &thermo) {
-    real r = sqrt((x - xc) * (x - xc) + (z - bzc) * (z - bzc));
+    real r = (x - xc) * (x - xc) + (z - bzc) * (z - bzc);
+    if (ndims > 1) {
+      r += (y - yc) * (y - yc);
+    }
+    r = std::sqrt(r);
+
     real rh = (r < rc) ? rh0 * 0.5_fp * (1._fp + cos(pi * r / rc)) : 0._fp;
     real Th = isentropic_T(z, theta0, g, thermo);
     real svp = saturation_vapor_pressure(Th);

--- a/dynamics/spam/src/models/extrudedmodel.h
+++ b/dynamics/spam/src/models/extrudedmodel.h
@@ -1309,6 +1309,8 @@ public:
 
     YAKL_SCOPE(varset, this->equations->varset);
     YAKL_SCOPE(q_di, this->equations->reference_state.q_di.data);
+    YAKL_SCOPE(q_pi, this->equations->reference_state.q_pi.data);
+    YAKL_SCOPE(refdens, this->equations->reference_state.dens.data);
     YAKL_SCOPE(primal_geometry, this->primal_geometry);
     YAKL_SCOPE(dual_geometry, this->dual_geometry);
 
@@ -1323,10 +1325,14 @@ public:
           for (int d = 0; d < VS::ndensity_diffused; ++d) {
             int dens_id = varset.diffused_dens_ids(d);
             real dens0 = densvar(dens_id, k + dks, j + djs, i + dis, n);
-            dens0 /= total_dens;
             if (subtract_refstate) {
-              dens0 -= q_di(dens_id, k + dks, n);
+              dens0 -= refdens(dens_id, k + dks, n);
             }
+            dens0 /= total_dens;
+            //if (subtract_refstate) {
+            //  //dens0 -= q_di(dens_id, k + dks, n);
+            //  dens0 -= q_pi(dens_id, k + pks, n);
+            //}
             dens0var(d, k + pks, j + pjs, i + pis, n) = dens0;
           }
         });

--- a/dynamics/spam/src/models/extrudedmodel.h
+++ b/dynamics/spam/src/models/extrudedmodel.h
@@ -2770,7 +2770,7 @@ public:
   }
 #endif
 
-  void remove_negative_densities(FieldSet<nprognostic> &x) override {
+  void clip_negative_densities(FieldSet<nprognostic> &x) override {
     const auto &dual_topology = dual_geometry.topology;
 
     const auto densvar = x.fields_arr[DENSVAR].data;

--- a/dynamics/spam/src/models/extrudedmodel.h
+++ b/dynamics/spam/src/models/extrudedmodel.h
@@ -3991,6 +3991,10 @@ real YAKL_INLINE saturation_vapor_pressure(real temp) {
   return 610.94_fp * exp(17.625_fp * tc / (243.04_fp + tc));
 }
 
+real YAKL_INLINE saturation_mixing_ratio(real T, real p) {
+  return 380 / p * exp(17.27 * (T - 273) / (T - 36));
+}
+
 template <class T> class SWETestCase : public TestCase, public T {
 public:
   using T::g;
@@ -4305,11 +4309,6 @@ public:
     return T::rho_f(x, y, z, thermo);
 #endif
   }
-  using T::entropicvar_f;
-  using T::refentropicdensity_f;
-  using T::refnsq_f;
-  using T::refrho_f;
-  using T::refrhov_f;
 
   std::array<real, 3> get_domain() const override {
     real Ly = 1;
@@ -4348,13 +4347,14 @@ public:
 #ifndef PAMC_MAN
       dual_geom.set_n1form_values(
           YAKL_LAMBDA(real x, real y, real z) {
-            return rho_f(x, y, z, thermo);
+            return T::rho_f(x, y, z, thermo);
           },
           progvars.fields_arr[DENSVAR], varset.dens_id_mass);
 #endif
       dual_geom.set_n1form_values(
           YAKL_LAMBDA(real x, real y, real z) {
-            return rho_f(x, y, z, thermo) * entropicvar_f(x, y, z, thermo);
+            return T::rho_f(x, y, z, thermo) *
+                   T::entropicvar_f(x, y, z, thermo);
           },
           progvars.fields_arr[DENSVAR], varset.dens_id_entr);
 
@@ -4368,7 +4368,7 @@ public:
       for (int i = 0; i < ntracers_dycore; i++) {
         dual_geom.set_n1form_values(
             YAKL_LAMBDA(real x, real y, real z) {
-              return rho_f(x, y, z, thermo) *
+              return T::rho_f(x, y, z, thermo) *
                      TracerFunctor{}(tracers(i), x, z, Lx, Lz, xc, zc);
             },
             progvars.fields_arr[DENSVAR], i + VS::ndensity_dycore_prognostic);
@@ -4397,14 +4397,14 @@ public:
       T::initialize_refstate(equations, primal_geom, dual_geom);
     } else {
       dual_geom.set_profile_n1form_values(
-          YAKL_LAMBDA(real z) { return refrho_f(z, thermo); }, refstate.dens,
+          YAKL_LAMBDA(real z) { return T::refrho_f(z, thermo); }, refstate.dens,
           varset.dens_id_mass);
       dual_geom.set_profile_n1form_values(
-          YAKL_LAMBDA(real z) { return refentropicdensity_f(z, thermo); },
+          YAKL_LAMBDA(real z) { return T::refentropicdensity_f(z, thermo); },
           refstate.dens, varset.dens_id_entr);
       dual_geom.set_profile_n1form_values(
-          YAKL_LAMBDA(real z) { return refrhov_f(z, thermo); }, refstate.dens,
-          varset.dens_id_vap);
+          YAKL_LAMBDA(real z) { return T::refrhov_f(z, thermo); },
+          refstate.dens, varset.dens_id_vap);
     }
 
     parallel_for(
@@ -4427,7 +4427,7 @@ public:
         });
 
     primal_geom.set_profile_00form_values(
-        YAKL_LAMBDA(real z) { return refnsq_f(z, thermo); }, refstate.Nsq_pi,
+        YAKL_LAMBDA(real z) { return T::refnsq_f(z, thermo); }, refstate.Nsq_pi,
         0);
 
     parallel_for(
@@ -5743,6 +5743,259 @@ template <bool add_perturbation> struct GravityWave : TestCaseInit {
   }
 };
 
+struct Supercell : TestCaseInit {
+  static int constexpr max_ndims = 2;
+  static bool constexpr needs_special_init = true;
+  static real constexpr g = 9.81;
+  static real constexpr Lx = 168e3;
+  static real constexpr Ly = 168e3;
+  static real constexpr Lz = 20e3;
+  static real constexpr xc = 0.5_fp * Lx;
+  static real constexpr yc = 0.5_fp * Ly;
+  static real constexpr zc = 0.5_fp * Lz;
+
+  static real constexpr xbc = 0.5_fp * Lx;
+  static real constexpr ybc = 0.5_fp * Ly;
+  static real constexpr zbc = 1.5e3;
+
+  static real constexpr rx = 10e3;
+  static real constexpr ry = 10e3;
+  static real constexpr rz = 1.5e3;
+
+  static real constexpr dtht = 3;
+  static real constexpr tht_0 = 300;
+  static real constexpr z_tr = 12e3;
+  static real constexpr tht_tr = 343;
+  static real constexpr T_tr = 213;
+
+  static real constexpr z_s = 5e3;
+  static real constexpr U_s = 30;
+  static real constexpr U_c = 15;
+  static real constexpr dz_u = 1e3;
+
+  static real constexpr N_ref = 1.235e-5;
+
+  static real YAKL_INLINE refnsq_f(real z, const ThermoPotential &thermo) {
+    return N_ref * N_ref;
+  }
+
+  static real YAKL_INLINE refp_f(real z, const ThermoPotential &thermo) {
+    return const_stability_p(z, N_ref, g, thermo.cst.pr, tht_0, thermo);
+  }
+
+  static real YAKL_INLINE refT_f(real z, const ThermoPotential &thermo) {
+    return const_stability_T(z, N_ref, g, tht_0, thermo);
+  }
+
+  static real YAKL_INLINE refrho_f(real z, const ThermoPotential &thermo) {
+    real p = refp_f(z, thermo);
+    real T = refT_f(z, thermo);
+    real alpha = thermo.compute_alpha(p, T, 1, 0, 0, 0);
+    return 1._fp / alpha;
+  }
+
+  static real YAKL_INLINE refentropicdensity_f(real z,
+                                               const ThermoPotential &thermo) {
+    real rho_ref = refrho_f(z, thermo);
+    real T_ref = refT_f(z, thermo);
+    real p_ref = refp_f(z, thermo);
+    return rho_ref *
+           thermo.compute_entropic_var_from_p_T(p_ref, T_ref, 1, 0, 0, 0);
+  }
+
+  static real YAKL_INLINE refrhov_f(real z, const ThermoPotential &thermo) {
+    return 0;
+  }
+
+  static real YAKL_INLINE tht_f(real z, const ThermoPotential &thermo) {
+    const real Cpd = thermo.cst.Cpd;
+    if (z <= z_tr) {
+      return tht_0 + (tht_tr - tht_0) * pow(z / z_tr, 5. / 4.);
+    } else {
+      return tht_tr * exp(g / (Cpd * T_tr) * (z - z_tr));
+    }
+  }
+
+  static real YAKL_INLINE hum_f(real z, const ThermoPotential &thermo) {
+    if (z <= z_tr) {
+      return 1 - 0.75 * pow(z / z_tr, 5. / 4.);
+    } else {
+      return 0.25;
+    }
+  }
+
+  static real YAKL_INLINE tht_perturb_f(real x, real y, real z,
+                                        const ThermoPotential &thermo) {
+    real dx = (x - xbc) / rx;
+    real dy = (y - ybc) / ry;
+    real dz = (z - zbc) / rz;
+    real r = sqrt(dx * dx + dy * dy + dz * dz);
+    return r < 1 ? dtht * pow(cos(pi * r / 2), 2) : 0;
+    // return 0;
+  }
+
+  static VecXYZ YAKL_INLINE v_f(real x, real y, real z) {
+    VecXYZ vvec;
+
+    real u_e;
+    if (z < z_s - dz_u) {
+      u_e = U_s * z / z_s - U_c;
+    } else if (abs(z - z_s) <= dz_u) {
+      u_e = (-4. / 5 + 3 * z / z_s - 5. / 4 * pow(z / z_s, 2)) * U_s - U_c;
+    } else if (z > z_s + dz_u) {
+      u_e = U_s - U_c;
+    }
+    vvec.u = u_e;
+    return vvec;
+  }
+
+  static void initialize_refstate(Equations *equations,
+                                  const Geometry<Straight> &primal_geometry,
+                                  const Geometry<Twisted> &dual_geometry) {
+
+    const auto &primal_topology = primal_geometry.topology;
+    const auto &dual_topology = dual_geometry.topology;
+
+    const int pis = primal_topology.is;
+    const int pjs = primal_topology.js;
+    const int pks = primal_topology.ks;
+
+    const int dis = dual_topology.is;
+    const int djs = dual_topology.js;
+    const int dks = dual_topology.ks;
+
+    real2d thtv("thtv", primal_topology.ni + 2 * primal_topology.mirror_halo,
+                primal_topology.nens);
+    real2d qv("qv", primal_topology.ni + 2 * primal_topology.mirror_halo,
+              primal_topology.nens);
+    real2d exner("exner", primal_topology.ni + 2 * primal_topology.mirror_halo,
+                 primal_topology.nens);
+
+    YAKL_SCOPE(thermo, equations->thermo);
+    YAKL_SCOPE(Hs, equations->Hs);
+    YAKL_SCOPE(varset, equations->varset);
+    YAKL_SCOPE(refstate, equations->reference_state);
+
+    thermo.cst.Rd = 287.;
+    thermo.cst.Rv = 461;
+    thermo.cst.pr = 1e5;
+    thermo.cst.Cpd = 1003;
+    thermo.cst.Cvd = thermo.cst.Cpd - thermo.cst.Rd;
+    thermo.cst.Cpv = 1859;
+
+    thermo.cst.gamma_d = thermo.cst.Cpd / thermo.cst.Cvd;
+    thermo.cst.kappa_d = thermo.cst.Rd / thermo.cst.Cpd;
+    thermo.cst.delta_d = thermo.cst.Rd / thermo.cst.Cvd;
+
+    const real pr = thermo.cst.pr;
+    const real Cpd = thermo.cst.Cpd;
+    const real kappa_d = thermo.cst.kappa_d;
+
+    parallel_for(
+        "Supercell set densities", primal_topology.nens, YAKL_LAMBDA(int n) {
+          // set intial thtv to tht
+          for (int k = 0; k < primal_topology.ni; ++k) {
+            real z = primal_geometry.zint(k + pks, n);
+            thtv(k + pks, n) = tht_f(z, thermo);
+          }
+
+          // iterate to solve nonlinear problem
+          for (int m = 0; m < 10; ++m) {
+            // compute exner
+            exner(0 + pks, n) = 1;
+            for (int k = 1; k < primal_topology.ni; ++k) {
+              // TODO: change to phi
+              real dz = primal_geometry.dz(k + pks, n);
+              exner(k + pks, n) =
+                  exner(k - 1 + pks, n) -
+                  g / (Cpd * (thtv(k - 1 + pks, n) + thtv(k + pks, n)) / 2) *
+                      dz;
+            }
+
+            // update thtv
+            for (int k = 0; k < primal_topology.ni; ++k) {
+              real z = primal_geometry.zint(k + pks, n);
+              real p = pr * std::pow(exner(k + pks, n), 1. / kappa_d);
+              real T = tht_f(z, thermo) * exner(k + pks, n);
+              real qvs = saturation_mixing_ratio(T, p);
+              qv(k + pks, n) = std::min(qvs * hum_f(z, thermo), 0.014);
+              real tht = tht_f(z, thermo);
+              thtv(k + pks, n) = tht * (1 + 0.61 * qv(k + pks, n));
+              // std::cout << m << " " << k << " " << tht << " " << thtv(k +
+              // pks, n)
+              // << std::endl;
+            }
+          }
+        });
+
+    parallel_for(
+        "Supercell set densitiy profiles",
+        SimpleBounds<2>(dual_topology.nl, dual_topology.nens),
+        YAKL_LAMBDA(int k, int n) {
+          real dual_volume =
+              dual_geometry.get_area_n1entity(k + dks, djs, dis, n);
+          real z = primal_geometry.zint(k + pks, n);
+          real rho = refrho_f(z, thermo);
+
+          refstate.dens.data(varset.dens_id_mass, k + dks, n) =
+              rho * dual_volume;
+          refstate.dens.data(varset.dens_id_entr, k + dks, n) =
+              rho * thtv(k + pks, n) * dual_volume;
+          refstate.dens.data(varset.dens_id_vap, k + dks, n) =
+              rho * qv(k + pks, n) * dual_volume;
+        });
+  }
+
+  static void initialize(Equations *equations, FieldSet<nprognostic> &progvars,
+                         FieldSet<nconstant> &constvars,
+                         const Geometry<Straight> &primal_geometry,
+                         const Geometry<Twisted> &dual_geometry) {
+
+    const auto &primal_topology = primal_geometry.topology;
+    const auto &dual_topology = dual_geometry.topology;
+
+    const int pis = primal_topology.is;
+    const int pjs = primal_topology.js;
+    const int pks = primal_topology.ks;
+
+    const int dis = dual_topology.is;
+    const int djs = dual_topology.js;
+    const int dks = dual_topology.ks;
+
+    YAKL_SCOPE(thermo, equations->thermo);
+    YAKL_SCOPE(varset, equations->varset);
+    YAKL_SCOPE(refdens, equations->reference_state.dens.data);
+
+    dual_geometry.set_n1form_values(
+        YAKL_LAMBDA(real x, real y, real z) {
+          return refrho_f(z, thermo) * tht_perturb_f(x, y, z, thermo);
+        },
+        progvars.fields_arr[DENSVAR], varset.dens_id_entr);
+
+    auto densvar = progvars.fields_arr[DENSVAR].data;
+    parallel_for(
+        "Supercell add refstate",
+        SimpleBounds<4>(dual_topology.nl, dual_topology.n_cells_y,
+                        dual_topology.n_cells_x, dual_topology.nens),
+        YAKL_LAMBDA(int k, int j, int i, int n) {
+          densvar(varset.dens_id_entr, k + dks, j + djs, i + dis, n) +=
+              refdens(varset.dens_id_entr, k + dks, n);
+          densvar(varset.dens_id_vap, k + dks, j + djs, i + dis, n) =
+              refdens(varset.dens_id_vap, k + dks, n);
+        });
+
+    primal_geometry.set_10form_values(
+        YAKL_LAMBDA(real x, real y, real z) { return v_f(x, y, z); },
+        progvars.fields_arr[VVAR], 0);
+    primal_geometry.set_01form_values(
+        YAKL_LAMBDA(real x, real y, real z) { return v_f(x, y, z); },
+        progvars.fields_arr[WVAR], 0);
+  }
+
+  static void
+  add_diagnostics(std::vector<std::unique_ptr<Diagnostic>> &diagnostics) {}
+};
+
 void testcase_from_string(std::unique_ptr<TestCase> &testcase, std::string name,
                           bool acoustic_balance) {
   if (name == "gravitywave") {
@@ -5759,6 +6012,8 @@ void testcase_from_string(std::unique_ptr<TestCase> &testcase, std::string name,
     testcase = std::make_unique<EulerTestCase<DensityCurrent>>();
   } else if (name == "moistrisingbubble") {
     testcase = std::make_unique<MoistEulerTestCase<MoistRisingBubble>>();
+  } else if (name == "supercell") {
+    testcase = std::make_unique<MoistEulerTestCase<Supercell>>();
   } else if (name == "largerisingbubble") {
     testcase = std::make_unique<EulerTestCase<LargeRisingBubble>>();
   } else if (name == "moistlargerisingbubble") {

--- a/dynamics/spam/src/models/extrudedmodel.h
+++ b/dynamics/spam/src/models/extrudedmodel.h
@@ -1325,14 +1325,10 @@ public:
           for (int d = 0; d < VS::ndensity_diffused; ++d) {
             int dens_id = varset.diffused_dens_ids(d);
             real dens0 = densvar(dens_id, k + dks, j + djs, i + dis, n);
-            if (subtract_refstate) {
-              dens0 -= refdens(dens_id, k + dks, n);
-            }
             dens0 /= total_dens;
-            //if (subtract_refstate) {
-            //  //dens0 -= q_di(dens_id, k + dks, n);
-            //  dens0 -= q_pi(dens_id, k + pks, n);
-            //}
+            if (subtract_refstate) {
+              dens0 -= q_pi(dens_id, k + pks, n);
+            }
             dens0var(d, k + pks, j + pjs, i + pis, n) = dens0;
           }
         });

--- a/dynamics/spam/src/models/extrudedmodel.h
+++ b/dynamics/spam/src/models/extrudedmodel.h
@@ -5775,7 +5775,7 @@ struct Supercell : TestCaseInit {
   static real constexpr U_c = 15;
   static real constexpr dz_u = 1e3;
 
-  static real constexpr N_ref = 1.235e-5;
+  static real constexpr N_ref = 0.011;
 
   static real YAKL_INLINE refnsq_f(real z, const ThermoPotential &thermo) {
     return N_ref * N_ref;

--- a/dynamics/spam/src/models/extrudedmodel.h
+++ b/dynamics/spam/src/models/extrudedmodel.h
@@ -2309,7 +2309,7 @@ public:
         needs_to_recompute_F ? auxiliary_vars.fields_arr[F2VAR].data
                              : auxiliary_vars.fields_arr[FVAR].data,
         needs_to_recompute_F ? auxiliary_vars.fields_arr[FW2VAR].data
-                             : auxiliary_vars.fields_arr[F2VAR].data,
+                             : auxiliary_vars.fields_arr[FWVAR].data,
         ndims > 1 ? optional_real5d{auxiliary_vars.fields_arr[FTXYVAR].data}
                   : std::nullopt);
 

--- a/dynamics/spam/src/models/extrudedmodel.h
+++ b/dynamics/spam/src/models/extrudedmodel.h
@@ -4876,7 +4876,12 @@ struct DoubleVortex {
   }
 };
 
-template <bool acoustic_balance> struct RisingBubble {
+// contains defualts
+struct TestCaseInit {
+  static int constexpr max_ndims = 1;
+};
+
+template <bool acoustic_balance> struct RisingBubble : TestCaseInit {
   static int constexpr max_ndims = 2;
   static real constexpr g = 9.80616_fp;
   static real constexpr Lx = 1000._fp;
@@ -4961,8 +4966,7 @@ template <bool acoustic_balance> struct RisingBubble {
   add_diagnostics(std::vector<std::unique_ptr<Diagnostic>> &diagnostics) {}
 };
 
-struct TwoBubbles {
-  static int constexpr max_ndims = 1;
+struct TwoBubbles : TestCaseInit {
   static real constexpr g = 9.80616_fp;
   static real constexpr Lx = 1000._fp;
   static real constexpr Lz = 1000._fp;
@@ -5054,8 +5058,7 @@ struct TwoBubbles {
   add_diagnostics(std::vector<std::unique_ptr<Diagnostic>> &diagnostics) {}
 };
 
-struct DensityCurrent {
-  static int constexpr max_ndims = 1;
+struct DensityCurrent : TestCaseInit {
   static real constexpr g = 9.80616_fp;
   static real constexpr Lx = 51.2e3;
   static real constexpr Lz = 6400;
@@ -5161,8 +5164,7 @@ struct MoistRisingBubble : public RisingBubble<false> {
   add_diagnostics(std::vector<std::unique_ptr<Diagnostic>> &diagnostics) {}
 };
 
-struct LargeRisingBubble {
-  static int constexpr max_ndims = 1;
+struct LargeRisingBubble : TestCaseInit {
   static real constexpr g = 9.80616_fp;
   static real constexpr Lx = 20000._fp;
   static real constexpr Lz = 20000._fp;
@@ -5273,8 +5275,7 @@ struct MoistLargeRisingBubble : LargeRisingBubble {
   }
 };
 
-template <bool add_perturbation> struct GravityWave {
-  static int constexpr max_ndims = 1;
+template <bool add_perturbation> struct GravityWave : TestCaseInit {
   static real constexpr g = 9.80616_fp;
   static real constexpr Lx = 300e3_fp;
   static real constexpr Lz = 10e3_fp;

--- a/dynamics/spam/src/models/extrudedmodel.h
+++ b/dynamics/spam/src/models/extrudedmodel.h
@@ -5887,7 +5887,6 @@ struct Supercell : TestCaseInit {
     real dz = (z - zbc) / rz;
     real r = sqrt(dx * dx + dy * dy + dz * dz);
     return r < 1 ? dtht * pow(cos(pi * r / 2), 2) : 0;
-    // return 0;
   }
 
   static VecXYZ YAKL_INLINE v_f(real x, real y, real z) {

--- a/dynamics/spam/src/models/model.h
+++ b/dynamics/spam/src/models/model.h
@@ -250,7 +250,7 @@ public:
     add_pressure_perturbation(dt, const_vars, x, auxiliary_vars, xtend);
   }
 
-  virtual void remove_negative_densities(FieldSet<nprognostic> &x) {}
+  virtual void clip_negative_densities(FieldSet<nprognostic> &x) {}
 };
 
 class ExtrudedTendencies : public Tendencies {

--- a/dynamics/spam/src/operators/recon.h
+++ b/dynamics/spam/src/operators/recon.h
@@ -477,7 +477,7 @@ void YAKL_INLINE compute_straight_recon(const real5d &reconvar,
       upwind_recon<ndofs, ndims>(recon, edgerecon, uvar);
     } else {
       for (int d = 0; d < ndims; ++d) {
-        uvar(d) /= pgeom.get_area_nm11entity(d, k + ks, j + js, is, n);
+        uvar(d) /= pgeom.get_area_nm11entity(d, k + ks, j + js, i + is, n);
       }
       tanh_upwind_recon<ndofs, ndims>(recon, edgerecon, uvar,
                                       tanh_upwind_coeff);
@@ -534,7 +534,7 @@ void YAKL_INLINE compute_straight_hz_recon(const real5d &reconvar,
       upwind_recon<ndofs, ndims>(recon, edgerecon, uvar);
     } else if (upwind_type == UPWIND_TYPE::TANH) {
       for (int d = 0; d < ndims; ++d) {
-        uvar(d) /= pgeom.get_area_nm11entity(d, k + ks, j + js, is, n);
+        uvar(d) /= pgeom.get_area_nm11entity(d, k + ks, j + js, i + is, n);
       }
       tanh_upwind_recon<ndofs, ndims>(recon, edgerecon, uvar,
                                       tanh_upwind_coeff);

--- a/physics/micro/kessler/Microphysics.h
+++ b/physics/micro/kessler/Microphysics.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "pam_coupler.h"
+#include <array>
 
 extern "C" void kessler_fortran(double *theta, double *qv, double *qc, double *qr, double *rho,
                                 double *pk, double &dt, double *z, int &nz, double &precl);
@@ -42,6 +43,14 @@ public:
 
   static int constexpr get_num_tracers() {
     return 3;
+  }
+  
+  static auto constexpr get_diffused_tracers_indices() {
+    return std::array{ID_V, ID_C, ID_R};
+  }
+
+  static auto constexpr get_num_diffused_tracers() {
+    return std::size(get_diffused_tracers_indices());
   }
 
 

--- a/physics/micro/kessler/Microphysics.h
+++ b/physics/micro/kessler/Microphysics.h
@@ -336,6 +336,7 @@ public:
 
   void kessler(real2d const &theta, real2d const &qv, real2d const &qc, real2d const &qr, realConst2d rho,
                real1d const &precl, realConst2d z, realConst2d pk, real dt, real Rd, real cp, real p0) const {
+    using yakl::c::SimpleBounds;
     int nz = theta.dimension[0];
     int ncol = theta.dimension[1];
 

--- a/physics/micro/none/Microphysics.h
+++ b/physics/micro/none/Microphysics.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "pam_coupler.h"
+#include <array>
 
 class Microphysics {
 public:
@@ -38,8 +39,13 @@ public:
   static int constexpr get_num_tracers() {
     return 1;
   }
-
-
+  
+  static auto constexpr get_diffused_tracers_indices() {
+    return std::array{0};
+  }
+  static auto constexpr get_num_diffused_tracers() {
+    return std::size(get_diffused_tracers_indices());
+  }
 
   // Have to declare at least water vapor
   void init(pam::PamCoupler &coupler) {

--- a/physics/micro/p3/Microphysics.h
+++ b/physics/micro/p3/Microphysics.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "pam_coupler.h"
+#include <array>
 // #include <stdio.h>
 
 #include "scream_cxx_interface_p3.h"
@@ -91,6 +92,14 @@ public:
   // This must return the correct # of tracers **BEFORE** init(...) is called
   static int constexpr get_num_tracers() {
     return 9;
+  }
+  
+  static auto constexpr get_diffused_tracers_indices() {
+    return std::array{ID_V, ID_C, ID_R, ID_I};
+  }
+
+  static auto constexpr get_num_diffused_tracers() {
+    return std::size(get_diffused_tracers_indices());
   }
 
 

--- a/standalone/mmf_simplified/CMakeLists.txt
+++ b/standalone/mmf_simplified/CMakeLists.txt
@@ -33,7 +33,7 @@ set_source_files_properties(supercell_init.F90 PROPERTY COMPILE_FLAGS "${YAKL_F9
 include(${YAKL_HOME}/yakl_utils.cmake)
 yakl_process_target(driver)
 
-if (PAM_SCREAM_USE_CXX)
+if (PAM_SCREAM_USE_CXX AND (PAM_MICRO STREQUAL "p3" OR PAM_SGS STREQUAL "shoc"))
   message(STATUS "*** building WITH C++ scream interface ***")
   target_compile_definitions(driver PUBLIC "-DP3_CXX -DSHOC_CXX")
   target_link_libraries(driver dynamics physics pam_core yaml-cpp "-L${CMAKE_CURRENT_BINARY_DIR}/../build_p3_shoc_cxx_interface -lpam_scream_cxx_interfaces -L${SCREAM_CXX_LIBS_DIR}/p3 -lp3 -L${SCREAM_CXX_LIBS_DIR}/shoc -lshoc -L${SCREAM_CXX_LIBS_DIR}/physics_share -lphysics_share -L${SCREAM_CXX_LIBS_DIR}/scream_share -lscream_share -L${SCREAM_CXX_LIBS_DIR}/externals/spdlog -lspdlog -L${SCREAM_CXX_LIBS_DIR} -lgptl -L${SCREAM_CXX_LIBS_DIR}/ekat/src/ekat -lekat -L${SCREAM_CXX_LIBS_DIR}/externals/kokkos/containers/src -lkokkoscontainers -L${SCREAM_CXX_LIBS_DIR}/externals/kokkos/core/src -lkokkoscore ${PAM_LINK_FLAGS} -ldl")

--- a/standalone/mmf_simplified/build/cmakescript_pamc.sh
+++ b/standalone/mmf_simplified/build/cmakescript_pamc.sh
@@ -6,6 +6,7 @@
 
 PAM_MICRO="p3"
 PAM_SGS="none"
+PAMC_NDIMS="1"
 PAMC_MODEL="extrudedmodel"
 PAMC_HAMIL="man"
 PAMC_THERMO="constkappavirpottemp"
@@ -36,6 +37,7 @@ cmake      \
   -DPAM_MICRO=${PAM_MICRO}                                        \
   -DPAM_SGS=${PAM_SGS}                                            \
   -DPAM_RAD="none"                                                \
+  -DPAMC_NDIMS=${PAMC_NDIMS}                                      \
   -DPAMC_MODEL=${PAMC_MODEL}                                      \
   -DPAMC_HAMIL=${PAMC_HAMIL}                                      \
   -DPAMC_THERMO=${PAMC_THERMO}                                    \

--- a/standalone/mmf_simplified/driver.cpp
+++ b/standalone/mmf_simplified/driver.cpp
@@ -190,6 +190,10 @@ int main(int argc, char** argv) {
     sgs   .init( coupler );
     dycore.init( coupler, verbose);
 
+#ifdef P3_CXX
+    pam::p3_init_lookup_tables();
+#endif
+
     if ( (micro.micro_name() == "p3" || sgs.sgs_name() == "shoc") && crm_nz != PAM_NLEV ) {
       endrun("ERROR: Running with a different number of vertical levels than compiled for");
     }

--- a/standalone/mmf_simplified/inputs/pamc_idealized/pamc_input_extruded_moistrisingbubble.yaml
+++ b/standalone/mmf_simplified/inputs/pamc_idealized/pamc_input_extruded_moistrisingbubble.yaml
@@ -1,7 +1,8 @@
 idealized : true
 verbose : true
+couple_wind : false
 
-sim_steps : 500
+sim_time : 500
 
 # Number of cells to use
 crm_nx : 100
@@ -27,7 +28,7 @@ dycore_out_prefix : test_dycore
 out_freq : 50
 stat_freq : 5
 
-tstype: si
+tstype: ssprk3
 
 # Number of ensembles
 nens : 1

--- a/standalone/mmf_simplified/inputs/pamc_idealized/pamc_input_extruded_supercell.yaml
+++ b/standalone/mmf_simplified/inputs/pamc_idealized/pamc_input_extruded_supercell.yaml
@@ -1,6 +1,7 @@
 idealized : true
 verbose : true
 check_anelastic_constraint : true
+force_refstate_hydrostatic_balance : true
 
 # Simulation time in seconds
 sim_time : 7200

--- a/standalone/mmf_simplified/inputs/pamc_idealized/pamc_input_extruded_supercell.yaml
+++ b/standalone/mmf_simplified/inputs/pamc_idealized/pamc_input_extruded_supercell.yaml
@@ -2,6 +2,7 @@ idealized : true
 verbose : true
 check_anelastic_constraint : true
 force_refstate_hydrostatic_balance : true
+couple_wind : false
 
 # Simulation time in seconds
 sim_time : 7200

--- a/standalone/mmf_simplified/inputs/pamc_idealized/pamc_input_extruded_supercell.yaml
+++ b/standalone/mmf_simplified/inputs/pamc_idealized/pamc_input_extruded_supercell.yaml
@@ -4,6 +4,7 @@ check_anelastic_constraint : true
 force_refstate_hydrostatic_balance : true
 velocity_diffusion_subtract_refstate : true
 couple_wind : false
+couple_wind_exact_inverse : true
 
 # Simulation time in seconds
 sim_time : 7200

--- a/standalone/mmf_simplified/inputs/pamc_idealized/pamc_input_extruded_supercell.yaml
+++ b/standalone/mmf_simplified/inputs/pamc_idealized/pamc_input_extruded_supercell.yaml
@@ -2,6 +2,7 @@ idealized : true
 verbose : true
 check_anelastic_constraint : true
 force_refstate_hydrostatic_balance : true
+velocity_diffusion_subtract_refstate : true
 couple_wind : false
 
 # Simulation time in seconds

--- a/standalone/mmf_simplified/inputs/pamc_idealized/pamc_input_extruded_supercell.yaml
+++ b/standalone/mmf_simplified/inputs/pamc_idealized/pamc_input_extruded_supercell.yaml
@@ -1,0 +1,46 @@
+idealized : true
+verbose : true
+
+# Simulation time in seconds
+sim_time : 7200
+
+# Number of cells to use
+crm_nx : 42
+crm_ny : 42
+crm_nz : 41
+
+scalar_horiz_diffusion_coeff : 1500
+scalar_vert_diffusion_coeff : 1500
+
+velocity_vort_horiz_diffusion_coeff : 500
+velocity_vort_vert_diffusion_coeff : 500
+velocity_div_horiz_diffusion_coeff : 500
+velocity_div_vert_diffusion_coeff : 500
+
+# Vertical height coordinates file
+vcoords : uniform
+
+# Data to initialize: doublevortex rb mrb
+init_data : supercell
+
+# Time steps
+dt_crm_phys : 10
+crm_per_phys : 1
+
+# Output filename
+out_prefix : test
+dycore_out_prefix : test_dycore
+
+# Output frequency in actual time
+out_freq : 600
+stat_freq : 10
+
+tstype : ssprk3
+
+# Number of ensembles
+nens : 1
+
+# Parallel decomposition
+inner_mpi : true
+nprocx : 1
+nprocy : 1

--- a/standalone/mmf_simplified/inputs/pamc_idealized/pamc_input_extruded_supercell.yaml
+++ b/standalone/mmf_simplified/inputs/pamc_idealized/pamc_input_extruded_supercell.yaml
@@ -1,5 +1,6 @@
 idealized : true
 verbose : true
+check_anelastic_constraint : true
 
 # Simulation time in seconds
 sim_time : 7200


### PR DESCRIPTION
This PR adds the 3D supercell test case. Additionally, it
- adds `PAMC_NDIMS` CMake variable to allow setting the number of dimensions
- renames `remove_negative_densities` to `clip_negative_densities` and makes it a runtime option
- adds a way for microphysics schemes to inform the dynamics which tracers need to be diffused