### PR TITLE
[PAM-C] Pressure-based semi-implicit compressible solver

### DIFF
--- a/dynamics/spam/Dycore.h
+++ b/dynamics/spam/Dycore.h
@@ -172,7 +172,7 @@ public:
     // The anelastic ref state must be set before tendency initialization
     testcase->set_reference_state(primal_geometry, dual_geometry);
 
-    linear_system = model_linear_system();
+    linear_system = model_linear_system(params);
 
     if (time_integrator->is_semi_implicit || !VariableSet::compressible) {
       linear_system->initialize(params, primal_geometry, dual_geometry,

--- a/dynamics/spam/Dycore.h
+++ b/dynamics/spam/Dycore.h
@@ -42,13 +42,13 @@ public:
   ExchangeSet<nconstant> const_exchange;
   ExchangeSet<nauxiliary> aux_exchange;
   FileIO io;
+  std::unique_ptr<LinearSystem> linear_system;
   ModelTendencies tendencies;
   std::vector<std::unique_ptr<Diagnostic>> diagnostics;
   Topology primal_topology;
   Topology dual_topology;
   ModelParameters params;
   Parallel par;
-  ModelLinearSystem linear_system;
   std::unique_ptr<TimeIntegrator> time_integrator;
 
   int ierr;
@@ -171,7 +171,16 @@ public:
     debug_print("start tendencies init", par.masterproc);
     // The anelastic ref state must be set before tendency initialization
     testcase->set_reference_state(primal_geometry, dual_geometry);
-    tendencies.initialize(params, equations, primal_geometry, dual_geometry);
+
+    linear_system = model_linear_system();
+
+    if (time_integrator->is_semi_implicit || !VariableSet::compressible) {
+      linear_system->initialize(params, primal_geometry, dual_geometry,
+                                equations);
+      linear_system->compute_coefficients(params.dtcrm);
+    }
+    tendencies.initialize(params, equations, *linear_system, primal_geometry,
+                          dual_geometry);
     debug_print("end tendencies init", par.masterproc);
 
     // EVENTUALLY THIS NEEDS TO BE MORE CLEVER IE POSSIBLY DO NOTHING BASED ON
@@ -189,13 +198,8 @@ public:
 
     // // Initialize the time integrator
     debug_print("start ts init", par.masterproc);
-    time_integrator->initialize(params, tendencies, linear_system,
-                                prognostic_vars, constant_vars, auxiliary_vars);
-    if (time_integrator->is_semi_implicit) {
-      linear_system.initialize(params, primal_geometry, dual_geometry,
-                               equations);
-      linear_system.compute_coefficients(params.dtcrm);
-    }
+    time_integrator->initialize(params, tendencies, prognostic_vars,
+                                constant_vars, auxiliary_vars);
     debug_print("end ts init", par.masterproc);
 
 #ifdef PAM_STANDALONE

--- a/dynamics/spam/src/common.h
+++ b/dynamics/spam/src/common.h
@@ -104,10 +104,10 @@ uint constexpr max_vert_reconstruction_order =
               coriolis_vert_reconstruction_order});
 
 enum class UPWIND_TYPE { HEAVISIDE, TANH };
-UPWIND_TYPE constexpr upwind_type = UPWIND_TYPE::TANH;
-UPWIND_TYPE constexpr dual_upwind_type = UPWIND_TYPE::TANH;
-UPWIND_TYPE constexpr vert_upwind_type = UPWIND_TYPE::TANH;
-UPWIND_TYPE constexpr dual_vert_upwind_type = UPWIND_TYPE::TANH;
+UPWIND_TYPE constexpr upwind_type = UPWIND_TYPE::HEAVISIDE;
+UPWIND_TYPE constexpr dual_upwind_type = UPWIND_TYPE::HEAVISIDE;
+UPWIND_TYPE constexpr vert_upwind_type = UPWIND_TYPE::HEAVISIDE;
+UPWIND_TYPE constexpr dual_vert_upwind_type = UPWIND_TYPE::HEAVISIDE;
 
 // How to handle PV flux term
 // ADD AL81-TYPE SCHEME HERE EVENTUALLY AS WELL

--- a/dynamics/spam/src/extrudedmodel-common.h
+++ b/dynamics/spam/src/extrudedmodel-common.h
@@ -116,6 +116,8 @@ public:
   bool force_refstate_hydrostatic_balance;
   bool check_anelastic_constraint;
 
+  std::string linear_system;
+
   realConst2d zint;
 };
 } // namespace pamc

--- a/dynamics/spam/src/hamiltonians/refstate.h
+++ b/dynamics/spam/src/hamiltonians/refstate.h
@@ -11,10 +11,12 @@ struct ReferenceState_SWE {
 #ifdef PAMC_EXTRUDED
   Profile dens;
   Profile geop;
-  Profile q_di;
   Profile q_pi;
-  Profile rho_di;
+  Profile q_di;
   Profile rho_pi;
+  Profile rho_di;
+  Profile pres_pi;
+  Profile pres_di;
   Profile Nsq_pi;
   Profile v;
   Profile B;
@@ -27,12 +29,15 @@ struct ReferenceState_SWE {
 #ifdef PAMC_EXTRUDED
     this->dens.initialize(dual_topology, "ref dens", 1, 1, VS::ndensity);
     this->geop.initialize(dual_topology, "ref geop", 1, 1, 1);
-    this->rho_pi.initialize(primal_topology, "refrho_pi", 0, 0, 1);
     this->q_pi.initialize(primal_topology, "refq_pi", 0, 0, VS::ndensity);
-    this->rho_di.initialize(dual_topology, "refrho_di", 0, 0, 1);
     this->q_di.initialize(dual_topology, "refq_di", 0, 0, VS::ndensity);
     this->v.initialize(primal_topology, "ref v", 1, 0, 1);
+    this->rho_pi.initialize(primal_topology, "refrho_pi", 0, 0, 1);
+    this->rho_di.initialize(dual_topology, "refrho_di", 0, 0, 1);
+    this->pres_pi.initialize(primal_topology, "refp_pi", 0, 0, 1);
+    this->pres_di.initialize(dual_topology, "refp_di", 0, 0, 1);
     this->Nsq_pi.initialize(primal_topology, "refNsq_pi", 0, 0, 1);
+    this->B.initialize(dual_topology, "ref B", 1, 1, VS::ndensity_active);
 #endif
 
     this->is_initialized = true;
@@ -42,10 +47,12 @@ struct ReferenceState_SWE {
 struct ReferenceState_Euler {
   Profile dens;
   Profile geop;
-  Profile q_di;
   Profile q_pi;
-  Profile rho_di;
+  Profile q_di;
   Profile rho_pi;
+  Profile rho_di;
+  Profile pres_pi;
+  Profile pres_di;
   Profile Nsq_pi;
   Profile v;
   Profile B;
@@ -57,10 +64,12 @@ struct ReferenceState_Euler {
 
     this->dens.initialize(dual_topology, "ref dens", 1, 1, VS::ndensity);
     this->geop.initialize(dual_topology, "ref geop", 1, 1, 1);
-    this->rho_pi.initialize(primal_topology, "refrho_pi", 0, 0, 1);
     this->q_pi.initialize(primal_topology, "refq_pi", 0, 0, VS::ndensity);
-    this->rho_di.initialize(dual_topology, "refrho_di", 0, 0, 1);
     this->q_di.initialize(dual_topology, "refq_di", 0, 0, VS::ndensity);
+    this->rho_pi.initialize(primal_topology, "refrho_pi", 0, 0, 1);
+    this->rho_di.initialize(dual_topology, "refrho_di", 0, 0, 1);
+    this->pres_pi.initialize(primal_topology, "refp_pi", 0, 0, 1);
+    this->pres_di.initialize(dual_topology, "refp_di", 0, 0, 1);
     this->Nsq_pi.initialize(primal_topology, "refNsq_pi", 0, 0, 1);
     this->v.initialize(primal_topology, "ref v", 1, 0, 1);
     this->B.initialize(dual_topology, "ref B", 1, 1, VS::ndensity_active);

--- a/dynamics/spam/src/hamiltonians/variableset.h
+++ b/dynamics/spam/src/hamiltonians/variableset.h
@@ -396,6 +396,9 @@ public:
                             int js, int is, int n) const;
   real YAKL_INLINE get_pres(int k, int ks, int n) const;
   real YAKL_INLINE get_ref_dens(int k, int ks, int n) const;
+
+  void linear_pressure_coeffs(SArray<real, 1, ndensity> &pres_coeffs, int k,
+                              int ks, int n) const;
 };
 
 // THIS IS ANELASTIC SPECIFIC FOR NOW, IDEALLY IT SHOULD MADE TO WORK FOR EITHER
@@ -1064,6 +1067,22 @@ real YAKL_INLINE VariableSetBase<VS_CE>::get_alpha(const real3d &densvar, int k,
                                                    int ks, int n) const {
   return dual_geometry.get_area_n1entity(k + ks, 0, 0, n) /
          densvar(dens_id_mass, k + ks, n);
+}
+
+template <>
+void YAKL_INLINE VariableSetBase<VS_CE>::linear_pressure_coeffs(
+    SArray<real, 1, ndensity> &pres_coeffs, int k, int ks, int n) const {
+
+  const real alpha = 1._fp / reference_state.rho_pi.data(0, k + ks, n);
+  const real entropic_var = reference_state.q_pi.data(dens_id_entr, k + ks, n);
+
+  const real cs = thermo.compute_soundspeed(alpha, entropic_var, 1, 0, 0, 0);
+  const real dpdrho = cs * cs;
+  const real dpdentropic_var =
+      thermo.compute_dpdentropic_var(alpha, entropic_var, 1, 0, 0, 0);
+
+  pres_coeffs(dens_id_mass) = dpdrho - entropic_var * alpha * dpdentropic_var;
+  pres_coeffs(dens_id_entr) = alpha * dpdentropic_var;
 }
 #endif
 

--- a/dynamics/spam/src/hamiltonians/variableset.h
+++ b/dynamics/spam/src/hamiltonians/variableset.h
@@ -397,8 +397,9 @@ public:
   real YAKL_INLINE get_pres(int k, int ks, int n) const;
   real YAKL_INLINE get_ref_dens(int k, int ks, int n) const;
 
-  void linear_pressure_coeffs(SArray<real, 1, ndensity_active> &pres_coeffs,
-                              int k, int ks, int n) const;
+  void YAKL_INLINE
+  linear_pressure_coeffs(SArray<real, 1, ndensity_active> &pres_coeffs, int k,
+                         int ks, int n) const {}
 };
 
 // THIS IS ANELASTIC SPECIFIC FOR NOW, IDEALLY IT SHOULD MADE TO WORK FOR EITHER

--- a/dynamics/spam/src/models/extrudedmodel.h
+++ b/dynamics/spam/src/models/extrudedmodel.h
@@ -3556,11 +3556,17 @@ struct CompressiblePressureLinearSystem : PressureLinearSystem {
             const real gamma_k = 1;
             const real gamma_km1 = 1;
 
-            const real beta_kp1 = q_di(d, k + 1 + dks, n) *
+            const real rhofac_kp1 =
+                rho_di(0, k + 1 + dks, n) * 0.5_fp *
+                (1 / rho_pi(0, k + 1 + pks, n) + 1 / rho_pi(0, k + pks, n));
+            const real beta_kp1 = q_di(d, k + 1 + dks, n) * rhofac_kp1 *
                                   H01_diagonal(primal_geometry, dual_geometry,
                                                pis, pjs, pks, i, j, k + 1, n);
 
-            const real beta_k = q_di(d, k + dks, n) *
+            const real rhofac_k =
+                rho_di(0, k + dks, n) * 0.5_fp *
+                (1 / rho_pi(0, k + pks, n) + 1 / rho_pi(0, k - 1 + pks, n));
+            const real beta_k = q_di(d, k + dks, n) * rhofac_k *
                                 H01_diagonal(primal_geometry, dual_geometry,
                                              pis, pjs, pks, i, j, k, n);
 

--- a/dynamics/spam/src/models/extrudedmodel.h
+++ b/dynamics/spam/src/models/extrudedmodel.h
@@ -6969,37 +6969,8 @@ struct Supercell : TestCaseInit {
   static real constexpr dz_u = 1e3;
 
   static real constexpr N_ref = 0.011;
-
   static real YAKL_INLINE refnsq_f(real z, const ThermoPotential &thermo) {
     return N_ref * N_ref;
-  }
-
-  static real YAKL_INLINE refp_f(real z, const ThermoPotential &thermo) {
-    return const_stability_p(z, N_ref, g, thermo.cst.pr, tht_0, thermo);
-  }
-
-  static real YAKL_INLINE refT_f(real z, const ThermoPotential &thermo) {
-    return const_stability_T(z, N_ref, g, tht_0, thermo);
-  }
-
-  static real YAKL_INLINE refrho_f(real z, const ThermoPotential &thermo) {
-    real p = refp_f(z, thermo);
-    real T = refT_f(z, thermo);
-    real alpha = thermo.compute_alpha(p, T, 1, 0, 0, 0);
-    return 1._fp / alpha;
-  }
-
-  static real YAKL_INLINE refentropicdensity_f(real z,
-                                               const ThermoPotential &thermo) {
-    real rho_ref = refrho_f(z, thermo);
-    real T_ref = refT_f(z, thermo);
-    real p_ref = refp_f(z, thermo);
-    return rho_ref *
-           thermo.compute_entropic_var_from_p_T(p_ref, T_ref, 1, 0, 0, 0);
-  }
-
-  static real YAKL_INLINE refrhov_f(real z, const ThermoPotential &thermo) {
-    return 0;
   }
 
   static real YAKL_INLINE tht_f(real z, const ThermoPotential &thermo) {

--- a/dynamics/spam/src/models/extrudedmodel.h
+++ b/dynamics/spam/src/models/extrudedmodel.h
@@ -190,7 +190,7 @@ void add_model_diagnostics(
 }
 
 // Unify interface with ModelLinearSystem
-struct AnelasticPressureSolver : LinearSystem {
+struct AnelasticLinearSystem : LinearSystem {
   Geometry<Straight> primal_geometry;
   Geometry<Twisted> dual_geometry;
   Equations *equations;
@@ -3432,7 +3432,7 @@ std::unique_ptr<LinearSystem> model_linear_system() {
   if (VariableSet::compressible) {
     return std::make_unique<ModelLinearSystem>();
   } else {
-    return std::make_unique<AnelasticPressureSolver>();
+    return std::make_unique<AnelasticLinearSystem>();
   }
 }
 

--- a/dynamics/spam/src/models/extrudedmodel.h
+++ b/dynamics/spam/src/models/extrudedmodel.h
@@ -6551,6 +6551,12 @@ struct Supercell : TestCaseInit {
     YAKL_SCOPE(varset, equations->varset);
     YAKL_SCOPE(refdens, equations->reference_state.dens.data);
 
+#ifndef PAMC_MAN
+    dual_geometry.set_n1form_values(
+        YAKL_LAMBDA(real x, real y, real z) { return refrho_f(z, thermo); },
+        progvars.fields_arr[DENSVAR], varset.dens_id_mass);
+#endif
+
     dual_geometry.set_n1form_values(
         YAKL_LAMBDA(real x, real y, real z) {
           return refrho_f(z, thermo) * tht_perturb_f(x, y, z, thermo);

--- a/dynamics/spam/src/models/extrudedmodel.h
+++ b/dynamics/spam/src/models/extrudedmodel.h
@@ -3674,7 +3674,7 @@ struct CompressiblePressureLinearSystem : PressureLinearSystem {
                         primal_topology.n_cells_x, primal_topology.nens),
         YAKL_LAMBDA(int k, int j, int i, int n) {
           p_transform(k, j, i, n) = 0;
-          for (int d = 0; d < VS::ndensity_prognostic; ++d) {
+          for (int d = 0; d < VS::ndensity_active; ++d) {
             p_transform(k, j, i, n) +=
                 linp_coeff(d, k, n) * Bvar(d, k + pks, j + pjs, i + pis, n);
           }

--- a/dynamics/spam/src/models/extrudedmodel.h
+++ b/dynamics/spam/src/models/extrudedmodel.h
@@ -4337,6 +4337,28 @@ public:
           Hs.compute_dHsdx(refstate.B.data, refstate.dens.data,
                            refstate.geop.data, pks, k, n, -1);
         });
+
+    parallel_for(
+        "Compute refstate pres_pi",
+        SimpleBounds<2>(primal_topology.ni, primal_topology.nens),
+        YAKL_LAMBDA(int k, int n) {
+          const real rho = refstate.rho_pi.data(0, k + pks, n);
+          const real entropicvar =
+              refstate.q_pi.data(varset.dens_id_entr, k + pks, n);
+          refstate.pres_pi.data(0, k + pks, n) =
+              thermo.solve_p(rho, entropicvar, 1, 0, 0, 0);
+        });
+
+    parallel_for(
+        "Compute refstate pres_di",
+        SimpleBounds<2>(dual_topology.ni, dual_topology.nens),
+        YAKL_LAMBDA(int k, int n) {
+          const real rho = refstate.rho_di.data(0, k + dks, n);
+          const real entropicvar =
+              refstate.q_di.data(varset.dens_id_entr, k + dks, n);
+          refstate.pres_di.data(0, k + dks, n) =
+              thermo.solve_p(rho, entropicvar, 1, 0, 0, 0);
+        });
   }
 };
 
@@ -4533,6 +4555,30 @@ public:
         YAKL_LAMBDA(int k, int n) {
           Hs.compute_dHsdx(refstate.B.data, refstate.dens.data,
                            refstate.geop.data, pks, k, n, -1);
+        });
+
+    parallel_for(
+        "Compute refstate pres_pi",
+        SimpleBounds<2>(primal_topology.ni, primal_topology.nens),
+        YAKL_LAMBDA(int k, int n) {
+          const real rho = refstate.rho_pi.data(0, k + pks, n);
+          const real entropicvar =
+              refstate.q_pi.data(varset.dens_id_entr, k + pks, n);
+          const real qv = refstate.q_pi.data(varset.dens_id_vap, k + pks, n);
+          refstate.pres_pi.data(0, k + pks, n) =
+              thermo.solve_p(rho, entropicvar, 1 - qv, qv, 0, 0);
+        });
+
+    parallel_for(
+        "Compute refstate pres_di",
+        SimpleBounds<2>(dual_topology.ni, dual_topology.nens),
+        YAKL_LAMBDA(int k, int n) {
+          const real rho = refstate.rho_di.data(0, k + dks, n);
+          const real entropicvar =
+              refstate.q_di.data(varset.dens_id_entr, k + dks, n);
+          const real qv = refstate.q_di.data(varset.dens_id_vap, k + dks, n);
+          refstate.pres_di.data(0, k + dks, n) =
+              thermo.solve_p(rho, entropicvar, 1 - qv, qv, 0, 0);
         });
   }
 
@@ -4805,6 +4851,30 @@ public:
 
           refstate.Nsq_pi.data(0, k + pks, n) =
               grav / T * D1w * (dTdz + gamma_m) - grav / (1 + rv) * drvdz;
+        });
+
+    parallel_for(
+        "Compute refstate pres_pi",
+        SimpleBounds<2>(primal_topology.ni, primal_topology.nens),
+        YAKL_LAMBDA(int k, int n) {
+          const real rho = refstate.rho_pi.data(0, k + pks, n);
+          const real entropicvar =
+              refstate.q_pi.data(varset.dens_id_entr, k + pks, n);
+          const real qv = refstate.q_pi.data(varset.dens_id_vap, k + pks, n);
+          refstate.pres_pi.data(0, k + pks, n) =
+              thermo.solve_p(rho, entropicvar, 1 - qv, qv, 0, 0);
+        });
+
+    parallel_for(
+        "Compute refstate pres_di",
+        SimpleBounds<2>(dual_topology.ni, dual_topology.nens),
+        YAKL_LAMBDA(int k, int n) {
+          const real rho = refstate.rho_di.data(0, k + dks, n);
+          const real entropicvar =
+              refstate.q_di.data(varset.dens_id_entr, k + dks, n);
+          const real qv = refstate.q_di.data(varset.dens_id_vap, k + dks, n);
+          refstate.pres_di.data(0, k + dks, n) =
+              thermo.solve_p(rho, entropicvar, 1 - qv, qv, 0, 0);
         });
   }
 

--- a/dynamics/spam/src/models/extrudedmodel.h
+++ b/dynamics/spam/src/models/extrudedmodel.h
@@ -2796,7 +2796,7 @@ public:
 };
 
 // *******   Linear system   ***********//
-class ModelLinearSystem : public LinearSystem {
+class CompressibleLinearSystemVelocity : public LinearSystem {
 
   yakl::RealFFT1D<real> fftv_x;
   yakl::RealFFT1D<real> fftw_x;
@@ -3428,9 +3428,422 @@ public:
   }
 };
 
+class CompressibleLinearSystemPressure : public LinearSystem {
+
+  yakl::RealFFT1D<real> fftp_x;
+  yakl::RealFFT1D<real> fftp_y;
+
+  bool is_initialized = false;
+
+  int nxf, nyf;
+  int kfix;
+
+  real3d linp_coeff;
+  real4d p_transform;
+
+  real4d tri_l;
+  real4d tri_d;
+  real4d tri_u;
+  real4d tri_c;
+
+  using VS = VariableSet;
+
+public:
+  void initialize(ModelParameters &params,
+                  const Geometry<Straight> &primal_geom,
+                  const Geometry<Twisted> &dual_geom,
+                  Equations &equations) override {
+
+    LinearSystem::initialize(params, primal_geom, dual_geom, equations);
+
+    const auto &primal_topology = primal_geom.topology;
+
+    auto pni = primal_topology.ni;
+    auto pnl = primal_topology.nl;
+    auto nx = primal_topology.n_cells_x;
+    auto ny = primal_topology.n_cells_y;
+    auto nens = primal_topology.nens;
+
+    this->nxf = nx + 2 - nx % 2;
+    this->nyf = ndims > 1 ? ny + 2 - ny % 2 : ny;
+    this->kfix = pni / 2;
+
+    p_transform = real4d("p transform", pni, nyf, nxf, nens);
+    yakl::memset(p_transform, 0);
+
+    fftp_x.init(p_transform, 2, nx);
+    if (ndims > 1) {
+      fftp_y.init(p_transform, 1, ny);
+    }
+
+    linp_coeff = real3d("linp coeff", VS::ndensity, pni, nens);
+
+    tri_d = real4d("tri d", pni, nyf, nxf, nens);
+    tri_l = real4d("tri l", pni, nyf, nxf, nens);
+    tri_u = real4d("tri u", pni, nyf, nxf, nens);
+    tri_c = real4d("tri c", pni, nyf, nxf, nens);
+
+    this->is_initialized = true;
+  }
+
+  virtual void compute_coefficients(real dt) override {
+    const auto &refstate = this->equations->reference_state;
+    const auto &varset = this->equations->varset;
+
+    const auto &primal_topology = primal_geometry.topology;
+    const auto &dual_topology = dual_geometry.topology;
+
+    auto n_cells_x = dual_topology.n_cells_x;
+    auto n_cells_y = dual_topology.n_cells_y;
+    auto nens = dual_topology.nens;
+    auto nl = primal_topology.nl;
+    auto ni = primal_topology.ni;
+
+    int pis = primal_topology.is;
+    int pjs = primal_topology.js;
+    int pks = primal_topology.ks;
+    int dis = dual_topology.is;
+    int djs = dual_topology.js;
+    int dks = dual_topology.ks;
+
+    real alpha = dt / 2;
+
+    const auto &rho_pi = refstate.rho_pi.data;
+    const auto &q_pi = refstate.q_pi.data;
+    const auto &rho_di = refstate.rho_di.data;
+    const auto &q_di = refstate.q_di.data;
+    const auto &pres_pi = refstate.pres_pi.data;
+    const auto &pres_di = refstate.pres_di.data;
+
+    YAKL_SCOPE(primal_geometry, this->primal_geometry);
+    YAKL_SCOPE(dual_geometry, this->dual_geometry);
+    YAKL_SCOPE(tri_l, this->tri_l);
+    YAKL_SCOPE(tri_d, this->tri_d);
+    YAKL_SCOPE(tri_u, this->tri_u);
+    YAKL_SCOPE(linp_coeff, this->linp_coeff);
+
+    parallel_for(
+        "pres coeffs",
+        SimpleBounds<2>(primal_topology.ni, primal_topology.nens),
+        YAKL_LAMBDA(int k, int n) {
+          SArray<real, 1, VS::ndensity> p_coeff;
+          varset.linear_pressure_coeffs(p_coeff, k, pks, n);
+          for (int d = 0; d < VS::ndensity; ++d) {
+            linp_coeff(d, k, n) = p_coeff(d);
+          }
+        });
+
+    parallel_for(
+        "Compressible linear system coefficients",
+        SimpleBounds<4>(primal_topology.ni, nyf, nxf, primal_topology.nens),
+        YAKL_LAMBDA(int k, int j, int i, int n) {
+          int ik = i / 2;
+          int jk = j / 2;
+
+          SArray<real, 1, ndims> fH1;
+          fourier_H10<diff_ord>(fH1, primal_geometry, dual_geometry, pis, pjs,
+                                pks, ik, jk, k, 0, dual_topology.n_cells_x,
+                                dual_topology.n_cells_y, dual_topology.ni);
+
+          SArray<real, 1, ndims> fD0Dbar;
+          fourier_cwD0Dnm1bar(fD0Dbar, 1, ik, jk, k, dual_topology.n_cells_x,
+                              dual_topology.n_cells_y, dual_topology.ni);
+
+          real fHn1bar = fourier_Hn1bar<diff_ord>(
+              primal_geometry, dual_geometry, pis, pjs, pks, ik, jk, k, 0,
+              dual_topology.n_cells_x, dual_topology.n_cells_y,
+              dual_topology.nl);
+
+          tri_d(k, j, i, n) = 1;
+          tri_l(k, j, i, n) = 0;
+          tri_u(k, j, i, n) = 0;
+
+          for (int dd = 0; dd < VS::ndensity_prognostic; ++dd) {
+            for (int d = 0; d < ndims; ++d) {
+              tri_d(k, j, i, n) -= alpha * alpha * linp_coeff(dd, k, n) *
+                                   fHn1bar * fH1(d) * fD0Dbar(d) *
+                                   q_pi(dd, k + pks, n);
+            }
+          }
+
+          for (int d = 0; d < VS::ndensity_prognostic; ++d) {
+            const real gamma_kp1 = 1;
+            const real gamma_k = 1;
+            const real gamma_km1 = 1;
+
+            const real beta_kp1 = q_di(d, k + 1 + dks, n) *
+                                  H01_diagonal(primal_geometry, dual_geometry,
+                                               pis, pjs, pks, i, j, k + 1, n);
+
+            const real beta_k = q_di(d, k + dks, n) *
+                                H01_diagonal(primal_geometry, dual_geometry,
+                                             pis, pjs, pks, i, j, k, n);
+
+            // TODO: This is more tricky with higher order hodge stars !!!
+            const real alpha_k = -alpha * alpha * fHn1bar * linp_coeff(d, k, n);
+
+            tri_u(k, j, i, n) += alpha_k * beta_kp1 * gamma_kp1;
+            tri_l(k, j, i, n) += alpha_k * beta_k * gamma_km1;
+
+            if (k == 0) {
+              tri_d(k, j, i, n) += -alpha_k * beta_kp1 * gamma_k;
+            } else if (k == (primal_topology.ni - 1)) {
+              tri_d(k, j, i, n) += -alpha_k * beta_k * gamma_k;
+            } else {
+              tri_d(k, j, i, n) += -alpha_k * (beta_kp1 + beta_k) * gamma_k;
+            }
+          }
+        });
+  }
+
+  virtual void solve(real dt, FieldSet<nprognostic> &rhs,
+                     FieldSet<nconstant> &const_vars,
+                     FieldSet<nauxiliary> &auxiliary_vars,
+                     FieldSet<nprognostic> &solution) override {
+    yakl::timer_start("linear_solve");
+
+    const auto fvar = auxiliary_vars.fields_arr[FVAR].data;
+    const auto fwvar = auxiliary_vars.fields_arr[FWVAR].data;
+    const auto Bvar = auxiliary_vars.fields_arr[BVAR].data;
+
+    const auto sol_dens = solution.fields_arr[DENSVAR].data;
+    const auto sol_v = solution.fields_arr[VVAR].data;
+    const auto sol_w = solution.fields_arr[WVAR].data;
+
+    const auto rhs_v = rhs.fields_arr[VVAR].data;
+    const auto rhs_w = rhs.fields_arr[WVAR].data;
+    const auto rhs_dens = rhs.fields_arr[DENSVAR].data;
+
+    const auto &primal_topology = primal_geometry.topology;
+    const auto &dual_topology = dual_geometry.topology;
+    const int pis = primal_topology.is;
+    const int pjs = primal_topology.js;
+    const int pks = primal_topology.ks;
+    const int dis = dual_topology.is;
+    const int djs = dual_topology.js;
+    const int dks = dual_topology.ks;
+
+    YAKL_SCOPE(nxf, this->nxf);
+    YAKL_SCOPE(nyf, this->nyf);
+
+    const auto &refstate = this->equations->reference_state;
+    const auto &rho_pi = refstate.rho_pi.data;
+    const auto &rho_di = refstate.rho_di.data;
+    const auto &q_pi = refstate.q_pi.data;
+    const auto &q_di = refstate.q_di.data;
+
+    YAKL_SCOPE(fftp_x, this->fftp_x);
+    YAKL_SCOPE(fftp_y, this->fftp_y);
+    YAKL_SCOPE(tri_l, this->tri_l);
+    YAKL_SCOPE(tri_u, this->tri_u);
+    YAKL_SCOPE(tri_d, this->tri_d);
+    YAKL_SCOPE(tri_c, this->tri_c);
+    YAKL_SCOPE(p_transform, this->p_transform);
+    YAKL_SCOPE(primal_geometry, this->primal_geometry);
+    YAKL_SCOPE(dual_geometry, this->dual_geometry);
+
+    parallel_for(
+        "Linear solve rhs 1",
+        SimpleBounds<4>(dual_topology.nl, dual_topology.n_cells_y,
+                        dual_topology.n_cells_x, dual_topology.nens),
+        YAKL_LAMBDA(int k, int j, int i, int n) {
+          SArray<real, 2, 1, ndims> u;
+          compute_H10<1, diff_ord>(u, rhs_v, primal_geometry, dual_geometry,
+                                   dis, djs, dks, i, j, k, n);
+
+          for (int d = 0; d < ndims; ++d) {
+            fvar(d, k + dks, j + djs, i + dis, n) =
+                u(0, d) * rho_pi(0, k + pks, n);
+          }
+
+          if (k < dual_topology.ni - 2) {
+            SArray<real, 1, 1> uw;
+            compute_H01(uw, rhs_w, primal_geometry, dual_geometry, dis, djs,
+                        dks, i, j, k + 1, n);
+            fwvar(0, k + 1 + dks, j + djs, i + dis, n) =
+                uw(0) * rho_di(0, k + dks + 1, n);
+          }
+        });
+    auxiliary_vars.fields_arr[FWVAR].set_bnd(0.0);
+    auxiliary_vars.exchange({FVAR, FWVAR});
+
+    parallel_for(
+        "Linear solve rhs 2",
+        SimpleBounds<4>(dual_topology.nl, dual_topology.n_cells_y,
+                        dual_topology.n_cells_x, dual_topology.nens),
+        YAKL_LAMBDA(int k, int j, int i, int n) {
+          SArray<real, 1, VS::ndensity_prognostic> tend;
+          SArray<real, 1, VS::ndensity_prognostic> vtend;
+
+          compute_wDnm1bar<VS::ndensity_prognostic>(tend, q_pi, fvar, dis, djs,
+                                                    dks, i, j, k, n);
+          compute_wDnm1bar_vert<VS::ndensity_prognostic>(
+              vtend, q_di, fwvar, dis, djs, dks, i, j, k, n);
+
+          for (int d = 0; d < VS::ndensity_prognostic; ++d) {
+            sol_dens(d, k + dks, j + djs, i + dis, n) =
+                rhs_dens(d, k + dks, j + djs, i + dis, n);
+            sol_dens(d, k + dks, j + djs, i + dis, n) -= 0.5_fp * dt * tend(d);
+            sol_dens(d, k + dks, j + djs, i + dis, n) -= 0.5_fp * dt * vtend(d);
+          }
+        });
+    solution.exchange({DENSVAR});
+
+    parallel_for(
+        "Linear solve rhs 3",
+        SimpleBounds<4>(primal_topology.ni, primal_topology.n_cells_y,
+                        primal_topology.n_cells_x, primal_topology.nens),
+        YAKL_LAMBDA(int k, int j, int i, int n) {
+          compute_Hn1bar<VS::ndensity_prognostic, diff_ord, vert_diff_ord>(
+              Bvar, sol_dens, primal_geometry, dual_geometry, pis, pjs, pks, i,
+              j, k, n);
+        });
+
+    parallel_for(
+        "Linear solve rhs 4",
+        SimpleBounds<4>(primal_topology.ni, primal_topology.n_cells_y,
+                        primal_topology.n_cells_x, primal_topology.nens),
+        YAKL_LAMBDA(int k, int j, int i, int n) {
+          p_transform(k, j, i, n) = 0;
+          for (int d = 0; d < VS::ndensity_prognostic; ++d) {
+            p_transform(k, j, i, n) +=
+                linp_coeff(d, k, n) * Bvar(d, k + pks, j + pjs, i + pis, n);
+          }
+        });
+
+    yakl::timer_start("ffts");
+    fftp_x.forward_real(p_transform);
+    if (ndims > 1) {
+      fftp_y.forward_real(p_transform);
+    }
+    yakl::timer_stop("ffts");
+
+    parallel_for(
+        "Anelastic tridiagonal solve",
+        Bounds<3>(nyf, nxf, primal_topology.nens),
+        YAKL_LAMBDA(int j, int i, int n) {
+          int ik = i / 2;
+          int jk = j / 2;
+
+          int nz = primal_topology.ni;
+          tri_c(0, j, i, n) = tri_u(0, j, i, n) / tri_d(0, j, i, n);
+          for (int k = 1; k < nz - 1; ++k) {
+            tri_c(k, j, i, n) =
+                tri_u(k, j, i, n) /
+                (tri_d(k, j, i, n) - tri_l(k, j, i, n) * tri_c(k - 1, j, i, n));
+          }
+          p_transform(0, j, i, n) /= tri_d(0, j, i, n);
+          for (int k = 1; k < nz; ++k) {
+            p_transform(k, j, i, n) =
+                (p_transform(k, j, i, n) -
+                 tri_l(k, j, i, n) * p_transform(k - 1, j, i, n)) /
+                (tri_d(k, j, i, n) - tri_l(k, j, i, n) * tri_c(k - 1, j, i, n));
+          }
+          for (int k = nz - 2; k >= 0; --k) {
+            p_transform(k, j, i, n) -=
+                tri_c(k, j, i, n) * p_transform(k + 1, j, i, n);
+          }
+        });
+
+    yakl::timer_start("ffts");
+    fftp_x.inverse_real(p_transform);
+    if (ndims > 1) {
+      fftp_y.inverse_real(p_transform);
+    }
+    yakl::timer_stop("ffts");
+
+    parallel_for(
+        "Anelastic - store p",
+        SimpleBounds<4>(primal_topology.ni, primal_topology.n_cells_y,
+                        primal_topology.n_cells_x, primal_topology.nens),
+        YAKL_LAMBDA(int k, int j, int i, int n) {
+          Bvar(0, k + pks, j + pjs, i + pis, n) = p_transform(k, j, i, n);
+        });
+    auxiliary_vars.exchange({BVAR});
+
+    parallel_for(
+        "Anelastic - add pressure gradient W",
+        SimpleBounds<4>(primal_topology.nl, primal_topology.n_cells_y,
+                        primal_topology.n_cells_x, primal_topology.nens),
+        YAKL_LAMBDA(int k, int j, int i, int n) {
+          SArray<real, 1, 1> dpdz;
+          compute_D0_vert<1>(dpdz, Bvar, pis, pjs, pks, i, j, k, n);
+          real rho = rho_di(0, k + 1 + dks, n);
+          sol_w(0, k + pks, j + pjs, i + pis, n) =
+              rhs_w(0, k + pks, j + pjs, i + pis, n) -
+              0.5_fp * dt * dpdz(0) / rho;
+        });
+
+    parallel_for(
+        "Anelastic - add pressure gradient V",
+        SimpleBounds<4>(primal_topology.ni, primal_topology.n_cells_y,
+                        primal_topology.n_cells_x, primal_topology.nens),
+        YAKL_LAMBDA(int k, int j, int i, int n) {
+          SArray<real, 2, 1, ndims> dpdh;
+          compute_D0<1>(dpdh, Bvar, pis, pjs, pks, i, j, k, n);
+          for (int d = 0; d < ndims; ++d) {
+            real rho = rho_pi(0, k + pks, n);
+            sol_v(d, k + pks, j + pjs, i + pis, n) =
+                rhs_v(d, k + pks, j + pjs, i + pis, n) -
+                0.5_fp * dt * dpdh(0, d) / rho;
+          }
+        });
+
+    solution.exchange({VVAR});
+    solution.exchange({WVAR});
+
+    YAKL_SCOPE(Hk, this->equations->Hk);
+    parallel_for(
+        "Recover densities 1 - F/Fw",
+        SimpleBounds<4>(dual_topology.nl, dual_topology.n_cells_y,
+                        dual_topology.n_cells_x, dual_topology.nens),
+        YAKL_LAMBDA(int k, int j, int i, int n) {
+          SArray<real, 2, 1, ndims> u;
+          compute_H10<1, diff_ord>(u, sol_v, primal_geometry, dual_geometry,
+                                   dis, djs, dks, i, j, k, n);
+
+          for (int d = 0; d < ndims; ++d) {
+            fvar(d, k + dks, j + djs, i + dis, n) =
+                u(0, d) * rho_pi(0, k + pks, n);
+          }
+
+          if (k < dual_topology.ni - 2) {
+            SArray<real, 1, 1> uw;
+            compute_H01(uw, sol_w, primal_geometry, dual_geometry, dis, djs,
+                        dks, i, j, k + 1, n);
+            fwvar(0, k + 1 + dks, j + djs, i + dis, n) =
+                uw(0) * rho_di(0, k + dks + 1, n);
+          }
+        });
+
+    auxiliary_vars.fields_arr[FWVAR].set_bnd(0.0);
+    auxiliary_vars.exchange({FVAR, FWVAR});
+    yakl::memset(sol_dens, 0);
+
+    parallel_for(
+        "Recover densities 2 - Dnm1bar",
+        SimpleBounds<4>(dual_topology.nl, dual_topology.n_cells_y,
+                        dual_topology.n_cells_x, dual_topology.nens),
+        YAKL_LAMBDA(int k, int j, int i, int n) {
+          compute_wDnm1bar<VS::ndensity_prognostic>(sol_dens, q_pi, fvar, dis,
+                                                    djs, dks, i, j, k, n);
+          compute_wDnm1bar_vert<VS::ndensity_prognostic, ADD_MODE::ADD>(
+              sol_dens, q_di, fwvar, dis, djs, dks, i, j, k, n);
+          for (int d = 0; d < VS::ndensity_prognostic; ++d) {
+            sol_dens(d, k + dks, j + djs, i + dis, n) *= -dt / 2;
+            sol_dens(d, k + dks, j + djs, i + dis, n) +=
+                rhs_dens(d, pks + k, pjs + j, pis + i, n);
+          }
+        });
+
+    yakl::timer_stop("linear_solve");
+  }
+};
+
 std::unique_ptr<LinearSystem> model_linear_system() {
   if (VariableSet::compressible) {
-    return std::make_unique<ModelLinearSystem>();
+    // return std::make_unique<CompressibleLinearSystemVelocity>();
+    return std::make_unique<CompressibleLinearSystemPressure>();
   } else {
     return std::make_unique<AnelasticLinearSystem>();
   }

--- a/dynamics/spam/src/models/extrudedmodel.h
+++ b/dynamics/spam/src/models/extrudedmodel.h
@@ -3334,6 +3334,12 @@ struct AnelasticLinearSystem : PressureLinearSystem {
     YAKL_SCOPE(primal_geometry, this->primal_geometry);
     YAKL_SCOPE(dual_geometry, this->dual_geometry);
     YAKL_SCOPE(p_transform, this->p_transform);
+    YAKL_SCOPE(tri_l, this->tri_l);
+    YAKL_SCOPE(tri_d, this->tri_d);
+    YAKL_SCOPE(tri_u, this->tri_u);
+    YAKL_SCOPE(tri_c, this->tri_c);
+    YAKL_SCOPE(kfix, this->kfix);
+
     const auto &primal_topology = primal_geometry.topology;
     const auto &dual_topology = dual_geometry.topology;
 
@@ -3403,6 +3409,7 @@ struct AnelasticLinearSystem : PressureLinearSystem {
 
     YAKL_SCOPE(primal_geometry, this->primal_geometry);
     YAKL_SCOPE(dual_geometry, this->dual_geometry);
+    YAKL_SCOPE(p_transform, this->p_transform);
     const auto &primal_topology = primal_geometry.topology;
     const auto &dual_topology = dual_geometry.topology;
 

--- a/dynamics/spam/src/models/extrudedmodel.h
+++ b/dynamics/spam/src/models/extrudedmodel.h
@@ -3333,6 +3333,7 @@ struct AnelasticLinearSystem : PressureLinearSystem {
 
     YAKL_SCOPE(primal_geometry, this->primal_geometry);
     YAKL_SCOPE(dual_geometry, this->dual_geometry);
+    YAKL_SCOPE(p_transform, this->p_transform);
     const auto &primal_topology = primal_geometry.topology;
     const auto &dual_topology = dual_geometry.topology;
 

--- a/dynamics/spam/src/models/extrudedmodel.h
+++ b/dynamics/spam/src/models/extrudedmodel.h
@@ -2230,7 +2230,7 @@ public:
         needs_to_recompute_F ? auxiliary_vars.fields_arr[F2VAR].data
                              : auxiliary_vars.fields_arr[FVAR].data,
         needs_to_recompute_F ? auxiliary_vars.fields_arr[FW2VAR].data
-                             : auxiliary_vars.fields_arr[F2VAR].data,
+                             : auxiliary_vars.fields_arr[FWVAR].data,
         auxiliary_vars.fields_arr[FTVAR].data,
         auxiliary_vars.fields_arr[FTWVAR].data, this->tanh_upwind_coeff,
         ndims > 1 ? optional_real5d{auxiliary_vars.fields_arr[QXYRECONVAR].data}

--- a/dynamics/spam/src/models/extrudedmodel.h
+++ b/dynamics/spam/src/models/extrudedmodel.h
@@ -3967,6 +3967,13 @@ struct CompressiblePressureGravityLinearSystem
     YAKL_SCOPE(tri_d, this->tri_d);
     YAKL_SCOPE(tri_u, this->tri_u);
     YAKL_SCOPE(linp_coeff, this->linp_coeff);
+    YAKL_SCOPE(omega, this->omega);
+    YAKL_SCOPE(Dmod_u, this->Dmod_u);
+    YAKL_SCOPE(Dmod_d, this->Dmod_d);
+    YAKL_SCOPE(Fhorz, this->Fhorz);
+    YAKL_SCOPE(A_u, this->A_u);
+    YAKL_SCOPE(A_d, this->A_d);
+    YAKL_SCOPE(A_l, this->A_l);
 
     const auto &thermo = this->equations->thermo;
     parallel_for(
@@ -4090,7 +4097,7 @@ struct CompressiblePressureGravityLinearSystem
               dual_topology.nl);
 
           Fhorz(k, j, i, n) = 1;
-          for (int dd = 0; dd < VS::ndensity_prognostic; ++dd) {
+          for (int dd = 0; dd < VS::ndensity_active; ++dd) {
             for (int d = 0; d < ndims; ++d) {
               Fhorz(k, j, i, n) -= alpha * alpha * linp_coeff(dd, k, n) *
                                    fHn1bar * fH1(d) * fD0Dbar(d) *
@@ -4141,7 +4148,7 @@ struct CompressiblePressureGravityLinearSystem
               dual_topology.n_cells_x, dual_topology.n_cells_y,
               dual_topology.nl);
 
-          for (int d = 0; d < VS::ndensity_prognostic; ++d) {
+          for (int d = 0; d < VS::ndensity_active; ++d) {
             const real beta_k = fHn1bar_k * linp_coeff(d, k, n) /
                                 Fhorz(k, j, i, n) * Dmod_d(k, n);
             const real beta_kp1 = fHn1bar_kp1 * linp_coeff(d, k + 1, n) /
@@ -4190,6 +4197,13 @@ struct CompressiblePressureGravityLinearSystem
     const int dks = dual_topology.ks;
 
     const real alpha = 0.5_fp * dt;
+
+    YAKL_SCOPE(omega, this->omega);
+    YAKL_SCOPE(linp_coeff, this->linp_coeff);
+    YAKL_SCOPE(A_l, this->A_l);
+    YAKL_SCOPE(A_u, this->A_u);
+    YAKL_SCOPE(A_d, this->A_d);
+    YAKL_SCOPE(A_c, this->A_c);
 
     parallel_for(
         YAKL_AUTO_LABEL(),
@@ -4287,6 +4301,21 @@ struct CompressiblePressureGravityLinearSystem
     const auto &refstate = this->equations->reference_state;
     const auto &rho_di = refstate.rho_di.data;
     const auto &q_di = refstate.q_di.data;
+
+    YAKL_SCOPE(Dmod_u, this->Dmod_u);
+    YAKL_SCOPE(Dmod_d, this->Dmod_d);
+    YAKL_SCOPE(p_transform, this->p_transform);
+    YAKL_SCOPE(q_transform, this->q_transform);
+    YAKL_SCOPE(A_l, this->A_l);
+    YAKL_SCOPE(A_u, this->A_u);
+    YAKL_SCOPE(A_d, this->A_d);
+    YAKL_SCOPE(A_c, this->A_c);
+    YAKL_SCOPE(tri_l, this->tri_l);
+    YAKL_SCOPE(tri_u, this->tri_u);
+    YAKL_SCOPE(tri_d, this->tri_d);
+    YAKL_SCOPE(tri_c, this->tri_c);
+    YAKL_SCOPE(Fhorz, this->Fhorz);
+    YAKL_SCOPE(linp_coeff, this->linp_coeff);
 
     yakl::timer_start("ffts");
     fftp_x.forward_real(p_transform);
@@ -4402,6 +4431,14 @@ struct CompressiblePressureGravityLinearSystem
     const int dks = dual_topology.ks;
 
     const real alpha = 0.5_fp * dt;
+
+    YAKL_SCOPE(Dmod_u, this->Dmod_u);
+    YAKL_SCOPE(Dmod_d, this->Dmod_d);
+    YAKL_SCOPE(A_l, this->A_l);
+    YAKL_SCOPE(A_u, this->A_u);
+    YAKL_SCOPE(A_d, this->A_d);
+    YAKL_SCOPE(A_c, this->A_c);
+    YAKL_SCOPE(p_transform, this->p_transform);
 
     parallel_for(
         YAKL_AUTO_LABEL(),

--- a/dynamics/spam/src/models/extrudedmodel.h
+++ b/dynamics/spam/src/models/extrudedmodel.h
@@ -6532,7 +6532,9 @@ struct Supercell : TestCaseInit {
           real dual_volume =
               dual_geometry.get_area_n1entity(k + dks, djs, dis, n);
           real z = primal_geometry.zint(k + pks, n);
-          real rho = refrho_f(z, thermo);
+
+          real p = pr * std::pow(exner(k + pks, n), 1. / kappa_d);
+          real rho = p / (thermo.cst.Rd * exner(k + pks, n) * thtv(k + pks, n));
 
           refstate.dens.data(varset.dens_id_mass, k + dks, n) =
               rho * dual_volume;

--- a/dynamics/spam/src/models/extrudedmodel.h
+++ b/dynamics/spam/src/models/extrudedmodel.h
@@ -189,311 +189,6 @@ void add_model_diagnostics(
   diagnostics.emplace_back(std::make_unique<TotalDensityDiagnostic>());
 }
 
-// Unify interface with ModelLinearSystem
-struct AnelasticLinearSystem : LinearSystem {
-  Geometry<Straight> primal_geometry;
-  Geometry<Twisted> dual_geometry;
-  Equations *equations;
-
-  bool is_initialized = false;
-
-  yakl::RealFFT1D<real> fftp_x;
-  yakl::RealFFT1D<real> fftp_y;
-
-  int nxf, nyf;
-  int kfix;
-
-  real4d tri_l;
-  real4d tri_d;
-  real4d tri_u;
-  real4d tri_c;
-  real4d p_transform;
-
-  void initialize(ModelParameters &params,
-                  const Geometry<Straight> &primal_geom,
-                  const Geometry<Twisted> &dual_geom, Equations &equations) {
-
-    this->primal_geometry = primal_geom;
-    this->dual_geometry = dual_geom;
-    this->equations = &equations;
-
-    const auto &primal_topology = primal_geom.topology;
-
-    auto pni = primal_topology.ni;
-    auto pnl = primal_topology.nl;
-    auto nx = primal_topology.n_cells_x;
-    auto ny = primal_topology.n_cells_y;
-    auto nens = primal_topology.nens;
-
-    this->nxf = nx + 2 - nx % 2;
-    this->nyf = ndims > 1 ? ny + 2 - ny % 2 : ny;
-    this->kfix = pni / 2;
-
-    p_transform = real4d("p transform", pni, nyf, nxf, nens);
-    yakl::memset(p_transform, 0);
-
-    fftp_x.init(p_transform, 2, nx);
-    if (ndims > 1) {
-      fftp_y.init(p_transform, 1, ny);
-    }
-
-    tri_d = real4d("tri d", pni, nyf, nxf, nens);
-    tri_l = real4d("tri l", pni, nyf, nxf, nens);
-    tri_u = real4d("tri u", pni, nyf, nxf, nens);
-    tri_c = real4d("tri c", pni, nyf, nxf, nens);
-
-    this->is_initialized = true;
-  }
-
-  void compute_coefficients(real dt) {
-
-    const auto &refstate = this->equations->reference_state;
-
-    const auto &primal_topology = primal_geometry.topology;
-    const auto &dual_topology = dual_geometry.topology;
-
-    auto n_cells_x = dual_topology.n_cells_x;
-    auto n_cells_y = dual_topology.n_cells_y;
-    auto nens = dual_topology.nens;
-    auto nl = primal_topology.nl;
-    auto ni = primal_topology.ni;
-
-    int pis = primal_topology.is;
-    int pjs = primal_topology.js;
-    int pks = primal_topology.ks;
-    int dis = dual_topology.is;
-    int djs = dual_topology.js;
-    int dks = dual_topology.ks;
-
-    const auto &rho_pi = refstate.rho_pi.data;
-    // const auto &q_pi = refstate.q_pi.data;
-    const auto &rho_di = refstate.rho_di.data;
-    // const auto &q_di = refstate.q_di.data;
-    // const auto &Nsq_pi = refstate.Nsq_pi.data;
-
-    YAKL_SCOPE(thermo, this->equations->thermo);
-    YAKL_SCOPE(grav, this->equations->Hs.g);
-    YAKL_SCOPE(primal_geometry, this->primal_geometry);
-    YAKL_SCOPE(dual_geometry, this->dual_geometry);
-    YAKL_SCOPE(tri_l, this->tri_l);
-    YAKL_SCOPE(tri_d, this->tri_d);
-    YAKL_SCOPE(tri_u, this->tri_u);
-    YAKL_SCOPE(kfix, this->kfix);
-
-    parallel_for(
-        "Anelastic set coeffs",
-        SimpleBounds<4>(primal_topology.ni, nyf, nxf, primal_topology.nens),
-        YAKL_LAMBDA(int k, int j, int i, int n) {
-          int ik = i / 2;
-          int jk = j / 2;
-
-          SArray<real, 1, ndims> fH1;
-          fourier_H10<diff_ord>(fH1, primal_geometry, dual_geometry, pis, pjs,
-                                pks, ik, jk, k, 0, dual_topology.n_cells_x,
-                                dual_topology.n_cells_y, dual_topology.ni);
-
-          SArray<real, 1, ndims> fD0Dbar;
-          fourier_cwD0Dnm1bar(fD0Dbar, 1, ik, jk, k, dual_topology.n_cells_x,
-                              dual_topology.n_cells_y, dual_topology.ni);
-
-          tri_l(k, j, i, n) = 0;
-          tri_d(k, j, i, n) = 0;
-          for (int d = 0; d < ndims; ++d) {
-            tri_d(k, j, i, n) += fH1(d) * fD0Dbar(d) * rho_pi(0, k + pks, n);
-          }
-          tri_u(k, j, i, n) = 0;
-
-          const real h_k = rho_di(0, k + dks, n) *
-                           H01_diagonal(primal_geometry, dual_geometry, pis,
-                                        pjs, pks, i, j, k, n);
-          const real h_kp1 = rho_di(0, k + dks + 1, n) *
-                             H01_diagonal(primal_geometry, dual_geometry, pis,
-                                          pjs, pks, i, j, k + 1, n);
-
-          tri_u(k, j, i, n) += h_kp1;
-          tri_l(k, j, i, n) += h_k;
-
-          if (k == 0) {
-            tri_d(k, j, i, n) += -h_kp1;
-          } else if (k == (primal_topology.ni - 1)) {
-            tri_d(k, j, i, n) += -h_k;
-          } else {
-            tri_d(k, j, i, n) += -(h_kp1 + h_k);
-          }
-
-          // the tridiagonal system that we need to solve is formally singular
-          // because of Neumann conditons on both boundaries. To avoid issues
-          // with direct solve in the vertical we fix the horizontal mean of
-          // pressure at one vertical level
-          if (ik == 0 && jk == 0 && k == kfix) {
-            tri_d(k, j, i, n) = 1;
-            tri_u(k, j, i, n) = 0;
-            tri_l(k, j, i, n) = 0;
-          }
-        });
-  }
-
-  void solve(real dt, FieldSet<nprognostic> &rhs,
-             FieldSet<nconstant> &const_vars,
-             FieldSet<nauxiliary> &auxiliary_vars,
-             FieldSet<nprognostic> &solution) {
-
-    const auto Fvar = auxiliary_vars.fields_arr[FVAR].data;
-    const auto FWvar = auxiliary_vars.fields_arr[FWVAR].data;
-    const auto mfvar = auxiliary_vars.fields_arr[MFVAR].data;
-    const auto Bvar = auxiliary_vars.fields_arr[BVAR].data;
-    const auto sol_v = solution.fields_arr[VVAR].data;
-    const auto sol_w = solution.fields_arr[WVAR].data;
-    const auto rhs_v = rhs.fields_arr[VVAR].data;
-    const auto rhs_w = rhs.fields_arr[WVAR].data;
-
-    const auto &primal_topology = primal_geometry.topology;
-    const auto &dual_topology = dual_geometry.topology;
-    const int pis = primal_topology.is;
-    const int pjs = primal_topology.js;
-    const int pks = primal_topology.ks;
-    const int dis = dual_topology.is;
-    const int djs = dual_topology.js;
-    const int dks = dual_topology.ks;
-
-    YAKL_SCOPE(nxf, this->nxf);
-    YAKL_SCOPE(nyf, this->nyf);
-    YAKL_SCOPE(kfix, this->kfix);
-
-    const auto &refstate = this->equations->reference_state;
-    const auto &rho_pi = refstate.rho_pi.data;
-    const auto &rho_di = refstate.rho_di.data;
-
-    YAKL_SCOPE(fftp_x, this->fftp_x);
-    YAKL_SCOPE(fftp_y, this->fftp_y);
-    YAKL_SCOPE(tri_l, this->tri_l);
-    YAKL_SCOPE(tri_u, this->tri_u);
-    YAKL_SCOPE(tri_d, this->tri_d);
-    YAKL_SCOPE(tri_c, this->tri_c);
-    YAKL_SCOPE(p_transform, this->p_transform);
-    YAKL_SCOPE(primal_geometry, this->primal_geometry);
-    YAKL_SCOPE(dual_geometry, this->dual_geometry);
-    // const auto &q_pi = refstate.q_pi.data;
-    // const auto &q_di = refstate.q_di.data;
-    // const auto &Nsq_pi = refstate.Nsq_pi.data;
-
-    rhs.exchange({VVAR, WVAR});
-
-    // compute rhs
-    parallel_for(
-        "Anelastic F/FW of vel tend",
-        SimpleBounds<4>(dual_topology.nl, dual_topology.n_cells_y,
-                        dual_topology.n_cells_x, dual_topology.nens),
-        YAKL_LAMBDA(int k, int j, int i, int n) {
-          SArray<real, 2, 1, ndims> u;
-          compute_H10<1, diff_ord>(u, rhs_v, primal_geometry, dual_geometry,
-                                   dis, djs, dks, i, j, k, n);
-          for (int d = 0; d < ndims; ++d) {
-            Fvar(d, k + dks, j + djs, i + dis, n) =
-                u(0, d) * rho_pi(0, k + pks, n);
-          }
-
-          if (k < dual_topology.ni - 2) {
-            SArray<real, 1, 1> uw;
-            compute_H01(uw, rhs_w, primal_geometry, dual_geometry, dis, djs,
-                        dks, i, j, k + 1, n);
-            FWvar(0, k + 1 + dks, j + djs, i + dis, n) =
-                uw(0) * rho_di(0, k + dks + 1, n);
-          }
-        });
-    auxiliary_vars.fields_arr[FWVAR].set_bnd(0.0);
-    auxiliary_vars.exchange({FVAR, FWVAR});
-
-    parallel_for(
-        "Anelastic rhs",
-        SimpleBounds<4>(dual_topology.nl, dual_topology.n_cells_y,
-                        dual_topology.n_cells_x, dual_topology.nens),
-        YAKL_LAMBDA(int k, int j, int i, int n) {
-          compute_Dnm1bar<1>(mfvar, Fvar, dis, djs, dks, i, j, k, n);
-          compute_Dnm1bar_vert<1, ADD_MODE::ADD>(mfvar, FWvar, dis, djs, dks, i,
-                                                 j, k, n);
-        });
-
-    parallel_for(
-        "Anelastic p_transform",
-        SimpleBounds<4>(primal_topology.ni, primal_topology.n_cells_y,
-                        primal_topology.n_cells_x, primal_topology.nens),
-        YAKL_LAMBDA(int k, int j, int i, int n) {
-          p_transform(k, j, i, n) = -mfvar(0, k + pks, j + pjs, i + pis, n);
-        });
-
-    yakl::timer_start("ffts");
-    fftp_x.forward_real(p_transform);
-    if (ndims > 1) {
-      fftp_y.forward_real(p_transform);
-    }
-    yakl::timer_stop("ffts");
-
-    parallel_for(
-        "Anelastic tridiagonal solve",
-        Bounds<3>(nyf, nxf, primal_topology.nens),
-        YAKL_LAMBDA(int j, int i, int n) {
-          // set the horizontal mean of pressure to zero at k = kfix
-          int ik = i / 2;
-          int jk = j / 2;
-          if (ik == 0 && jk == 0) {
-            p_transform(kfix, j, i, n) = 0;
-          }
-          int nz = primal_topology.ni;
-          tri_c(0, j, i, n) = tri_u(0, j, i, n) / tri_d(0, j, i, n);
-          for (int k = 1; k < nz - 1; ++k) {
-            tri_c(k, j, i, n) =
-                tri_u(k, j, i, n) /
-                (tri_d(k, j, i, n) - tri_l(k, j, i, n) * tri_c(k - 1, j, i, n));
-          }
-          p_transform(0, j, i, n) /= tri_d(0, j, i, n);
-          for (int k = 1; k < nz; ++k) {
-            p_transform(k, j, i, n) =
-                (p_transform(k, j, i, n) -
-                 tri_l(k, j, i, n) * p_transform(k - 1, j, i, n)) /
-                (tri_d(k, j, i, n) - tri_l(k, j, i, n) * tri_c(k - 1, j, i, n));
-          }
-          for (int k = nz - 2; k >= 0; --k) {
-            p_transform(k, j, i, n) -=
-                tri_c(k, j, i, n) * p_transform(k + 1, j, i, n);
-          }
-        });
-
-    yakl::timer_start("ffts");
-    fftp_x.inverse_real(p_transform);
-    if (ndims > 1) {
-      fftp_y.inverse_real(p_transform);
-    }
-    yakl::timer_stop("ffts");
-
-    parallel_for(
-        "Anelastic - store p",
-        SimpleBounds<4>(primal_topology.ni, primal_topology.n_cells_y,
-                        primal_topology.n_cells_x, primal_topology.nens),
-        YAKL_LAMBDA(int k, int j, int i, int n) {
-          Bvar(0, k + pks, j + pjs, i + pis, n) = p_transform(k, j, i, n);
-        });
-    auxiliary_vars.exchange({BVAR});
-
-    parallel_for(
-        "Anelastic - add pressure gradient W",
-        SimpleBounds<4>(primal_topology.nl, primal_topology.n_cells_y,
-                        primal_topology.n_cells_x, primal_topology.nens),
-        YAKL_LAMBDA(int k, int j, int i, int n) {
-          compute_D0_vert<1, ADD_MODE::ADD>(sol_w, Bvar, pis, pjs, pks, i, j, k,
-                                            n);
-        });
-
-    parallel_for(
-        "Anelastic - add pressure gradient V",
-        SimpleBounds<4>(primal_topology.ni, primal_topology.n_cells_y,
-                        primal_topology.n_cells_x, primal_topology.nens),
-        YAKL_LAMBDA(int k, int j, int i, int n) {
-          compute_D0<1, ADD_MODE::ADD>(sol_v, Bvar, pis, pjs, pks, i, j, k, n);
-        });
-  }
-};
-
 struct TotalDensityFunctor {
   const VariableSet &varset;
   YAKL_INLINE real operator()(const real5d &densvar, int d, int k, int j, int i,
@@ -764,40 +459,6 @@ public:
 
     if (ndims > 1) {
       auto FTxyvar = opt_FTxyvar.value();
-      parallel_for(
-          "Compute FTvar",
-          SimpleBounds<4>(primal_topology.ni - 2, primal_topology.n_cells_y,
-                          primal_topology.n_cells_x, primal_topology.nens),
-          YAKL_LAMBDA(int k, int j, int i, int n) {
-            compute_Wyz_u(FTvar, FWvar, pis, pjs, pks, i, j, k + 1, n);
-          });
-      parallel_for(
-          "Compute FTvar bnd",
-          SimpleBounds<3>(primal_topology.n_cells_y, primal_topology.n_cells_x,
-                          primal_topology.nens),
-          YAKL_LAMBDA(int j, int i, int n) {
-            compute_Wyz_u_bottom(FTvar, FWvar, pis, pjs, pks, i, j, 0, n);
-            compute_Wyz_u_top(FTvar, FWvar, pis, pjs, pks, i, j,
-                              primal_topology.ni - 1, n);
-          });
-
-      parallel_for(
-          "Compute FTWvar",
-          SimpleBounds<4>(primal_topology.nl - 2, primal_topology.n_cells_y,
-                          primal_topology.n_cells_x, primal_topology.nens),
-          YAKL_LAMBDA(int k, int j, int i, int n) {
-            compute_Wyz_w(FTWvar, Fvar, pis, pjs, pks, i, j, k + 1, n);
-          });
-      parallel_for(
-          "Compute FTWvar bnd",
-          SimpleBounds<3>(primal_topology.n_cells_y, primal_topology.n_cells_x,
-                          primal_topology.nens),
-          YAKL_LAMBDA(int j, int i, int n) {
-            compute_Wyz_w_bottom(FTWvar, Fvar, pis, pjs, pks, i, j, 0, n);
-            compute_Wyz_w_top(FTWvar, Fvar, pis, pjs, pks, i, j,
-                              primal_topology.nl - 1, n);
-          });
-
       parallel_for(
           "Compute FTXY",
           SimpleBounds<4>(primal_topology.ni, primal_topology.n_cells_y,
@@ -2796,7 +2457,7 @@ public:
 };
 
 // *******   Linear system   ***********//
-class CompressibleLinearSystemVelocity : public LinearSystem {
+class CompressibleVelocityLinearSystem : public LinearSystem {
 
   yakl::RealFFT1D<real> fftv_x;
   yakl::RealFFT1D<real> fftw_x;
@@ -3428,17 +3089,13 @@ public:
   }
 };
 
-class CompressibleLinearSystemPressure : public LinearSystem {
-
+struct PressureLinearSystem : public LinearSystem {
   yakl::RealFFT1D<real> fftp_x;
   yakl::RealFFT1D<real> fftp_y;
 
   bool is_initialized = false;
 
   int nxf, nyf;
-  int kfix;
-
-  real3d linp_coeff;
   real4d p_transform;
 
   real4d tri_l;
@@ -3466,7 +3123,6 @@ public:
 
     this->nxf = nx + 2 - nx % 2;
     this->nyf = ndims > 1 ? ny + 2 - ny % 2 : ny;
-    this->kfix = pni / 2;
 
     p_transform = real4d("p transform", pni, nyf, nxf, nens);
     yakl::memset(p_transform, 0);
@@ -3476,8 +3132,6 @@ public:
       fftp_y.init(p_transform, 1, ny);
     }
 
-    linp_coeff = real3d("linp coeff", VS::ndensity, pni, nens);
-
     tri_d = real4d("tri d", pni, nyf, nxf, nens);
     tri_l = real4d("tri l", pni, nyf, nxf, nens);
     tri_u = real4d("tri u", pni, nyf, nxf, nens);
@@ -3486,7 +3140,326 @@ public:
     this->is_initialized = true;
   }
 
-  virtual void compute_coefficients(real dt) override {
+  virtual void prepare_pressure_rhs(real dt, FieldSet<nprognostic> &rhs,
+                                    FieldSet<nconstant> &const_vars,
+                                    FieldSet<nauxiliary> &auxiliary_vars) = 0;
+
+  virtual void solve_for_pressure(real dt, FieldSet<nprognostic> &rhs,
+                                  FieldSet<nconstant> &const_vars,
+                                  FieldSet<nauxiliary> &auxiliary_vars) = 0;
+
+  virtual void update_velocity(real dt, FieldSet<nprognostic> &rhs,
+                               FieldSet<nconstant> &const_vars,
+                               FieldSet<nauxiliary> &auxiliary_vars,
+                               FieldSet<nprognostic> &solution) = 0;
+
+  virtual void update_densities(real dt, FieldSet<nprognostic> &rhs,
+                                FieldSet<nconstant> &const_vars,
+                                FieldSet<nauxiliary> &auxiliary_vars,
+                                FieldSet<nprognostic> &solution) = 0;
+
+  void solve(real dt, FieldSet<nprognostic> &rhs,
+             FieldSet<nconstant> &const_vars,
+             FieldSet<nauxiliary> &auxiliary_vars,
+             FieldSet<nprognostic> &solution) override {
+
+    prepare_pressure_rhs(dt, rhs, const_vars, auxiliary_vars);
+    solve_for_pressure(dt, rhs, const_vars, auxiliary_vars);
+    update_velocity(dt, rhs, const_vars, auxiliary_vars, solution);
+    update_densities(dt, rhs, const_vars, auxiliary_vars, solution);
+  }
+};
+
+struct AnelasticLinearSystem : PressureLinearSystem {
+  int kfix;
+
+  void initialize(ModelParameters &params,
+                  const Geometry<Straight> &primal_geom,
+                  const Geometry<Twisted> &dual_geom,
+                  Equations &equations) override {
+    PressureLinearSystem::initialize(params, primal_geom, dual_geom, equations);
+    this->kfix = primal_geom.topology.ni / 2;
+  }
+
+  void compute_coefficients(real dt) override {
+    const auto &refstate = this->equations->reference_state;
+
+    const auto &primal_topology = primal_geometry.topology;
+    const auto &dual_topology = dual_geometry.topology;
+
+    auto n_cells_x = dual_topology.n_cells_x;
+    auto n_cells_y = dual_topology.n_cells_y;
+    auto nens = dual_topology.nens;
+    auto nl = primal_topology.nl;
+    auto ni = primal_topology.ni;
+
+    int pis = primal_topology.is;
+    int pjs = primal_topology.js;
+    int pks = primal_topology.ks;
+    int dis = dual_topology.is;
+    int djs = dual_topology.js;
+    int dks = dual_topology.ks;
+
+    const auto &rho_pi = refstate.rho_pi.data;
+    const auto &rho_di = refstate.rho_di.data;
+
+    YAKL_SCOPE(thermo, this->equations->thermo);
+    YAKL_SCOPE(grav, this->equations->Hs.g);
+    YAKL_SCOPE(primal_geometry, this->primal_geometry);
+    YAKL_SCOPE(dual_geometry, this->dual_geometry);
+    YAKL_SCOPE(tri_l, this->tri_l);
+    YAKL_SCOPE(tri_d, this->tri_d);
+    YAKL_SCOPE(tri_u, this->tri_u);
+    YAKL_SCOPE(kfix, this->kfix);
+
+    parallel_for(
+        "Anelastic set coeffs",
+        SimpleBounds<4>(primal_topology.ni, nyf, nxf, primal_topology.nens),
+        YAKL_LAMBDA(int k, int j, int i, int n) {
+          int ik = i / 2;
+          int jk = j / 2;
+
+          SArray<real, 1, ndims> fH1;
+          fourier_H10<diff_ord>(fH1, primal_geometry, dual_geometry, pis, pjs,
+                                pks, ik, jk, k, 0, dual_topology.n_cells_x,
+                                dual_topology.n_cells_y, dual_topology.ni);
+
+          SArray<real, 1, ndims> fD0Dbar;
+          fourier_cwD0Dnm1bar(fD0Dbar, 1, ik, jk, k, dual_topology.n_cells_x,
+                              dual_topology.n_cells_y, dual_topology.ni);
+
+          tri_l(k, j, i, n) = 0;
+          tri_d(k, j, i, n) = 0;
+          for (int d = 0; d < ndims; ++d) {
+            tri_d(k, j, i, n) += fH1(d) * fD0Dbar(d) * rho_pi(0, k + pks, n);
+          }
+          tri_u(k, j, i, n) = 0;
+
+          const real h_k = rho_di(0, k + dks, n) *
+                           H01_diagonal(primal_geometry, dual_geometry, pis,
+                                        pjs, pks, i, j, k, n);
+          const real h_kp1 = rho_di(0, k + dks + 1, n) *
+                             H01_diagonal(primal_geometry, dual_geometry, pis,
+                                          pjs, pks, i, j, k + 1, n);
+
+          tri_u(k, j, i, n) += h_kp1;
+          tri_l(k, j, i, n) += h_k;
+
+          if (k == 0) {
+            tri_d(k, j, i, n) += -h_kp1;
+          } else if (k == (primal_topology.ni - 1)) {
+            tri_d(k, j, i, n) += -h_k;
+          } else {
+            tri_d(k, j, i, n) += -(h_kp1 + h_k);
+          }
+
+          // the tridiagonal system that we need to solve is formally singular
+          // because of Neumann conditons on both boundaries. To avoid issues
+          // with direct solve in the vertical we fix the horizontal mean of
+          // pressure at one vertical level
+          if (ik == 0 && jk == 0 && k == kfix) {
+            tri_d(k, j, i, n) = 1;
+            tri_u(k, j, i, n) = 0;
+            tri_l(k, j, i, n) = 0;
+          }
+        });
+  }
+
+  void prepare_pressure_rhs(real dt, FieldSet<nprognostic> &rhs,
+                            FieldSet<nconstant> &const_vars,
+                            FieldSet<nauxiliary> &auxiliary_vars) override {
+
+    YAKL_SCOPE(primal_geometry, this->primal_geometry);
+    YAKL_SCOPE(dual_geometry, this->dual_geometry);
+    const auto &primal_topology = primal_geometry.topology;
+    const auto &dual_topology = dual_geometry.topology;
+
+    const auto &refstate = this->equations->reference_state;
+    const auto &rho_pi = refstate.rho_pi.data;
+    const auto &rho_di = refstate.rho_di.data;
+
+    const auto Fvar = auxiliary_vars.fields_arr[FVAR].data;
+    const auto FWvar = auxiliary_vars.fields_arr[FWVAR].data;
+    const auto mfvar = auxiliary_vars.fields_arr[MFVAR].data;
+    const auto rhs_v = rhs.fields_arr[VVAR].data;
+    const auto rhs_w = rhs.fields_arr[WVAR].data;
+
+    const int pis = primal_topology.is;
+    const int pjs = primal_topology.js;
+    const int pks = primal_topology.ks;
+
+    const int dis = dual_topology.is;
+    const int djs = dual_topology.js;
+    const int dks = dual_topology.ks;
+
+    parallel_for(
+        "Anelastic rhs 1",
+        SimpleBounds<4>(dual_topology.nl, dual_topology.n_cells_y,
+                        dual_topology.n_cells_x, dual_topology.nens),
+        YAKL_LAMBDA(int k, int j, int i, int n) {
+          SArray<real, 2, 1, ndims> u;
+          compute_H10<1, diff_ord>(u, rhs_v, primal_geometry, dual_geometry,
+                                   dis, djs, dks, i, j, k, n);
+          for (int d = 0; d < ndims; ++d) {
+            Fvar(d, k + dks, j + djs, i + dis, n) =
+                u(0, d) * rho_pi(0, k + pks, n);
+          }
+
+          if (k < dual_topology.ni - 2) {
+            SArray<real, 1, 1> uw;
+            compute_H01(uw, rhs_w, primal_geometry, dual_geometry, dis, djs,
+                        dks, i, j, k + 1, n);
+            FWvar(0, k + 1 + dks, j + djs, i + dis, n) =
+                uw(0) * rho_di(0, k + dks + 1, n);
+          }
+        });
+    auxiliary_vars.fields_arr[FWVAR].set_bnd(0.0);
+    auxiliary_vars.exchange({FVAR, FWVAR});
+
+    parallel_for(
+        "Anelastic rhs 2",
+        SimpleBounds<4>(dual_topology.nl, dual_topology.n_cells_y,
+                        dual_topology.n_cells_x, dual_topology.nens),
+        YAKL_LAMBDA(int k, int j, int i, int n) {
+          compute_Dnm1bar<1>(mfvar, Fvar, dis, djs, dks, i, j, k, n);
+          compute_Dnm1bar_vert<1, ADD_MODE::ADD>(mfvar, FWvar, dis, djs, dks, i,
+                                                 j, k, n);
+        });
+  }
+
+  void solve_for_pressure(real dt, FieldSet<nprognostic> &rhs,
+                          FieldSet<nconstant> &const_vars,
+                          FieldSet<nauxiliary> &auxiliary_vars) override {
+
+    YAKL_SCOPE(primal_geometry, this->primal_geometry);
+    YAKL_SCOPE(dual_geometry, this->dual_geometry);
+    const auto &primal_topology = primal_geometry.topology;
+    const auto &dual_topology = dual_geometry.topology;
+
+    const auto mfvar = auxiliary_vars.fields_arr[MFVAR].data;
+
+    const int pis = primal_topology.is;
+    const int pjs = primal_topology.js;
+    const int pks = primal_topology.ks;
+
+    parallel_for(
+        "Anelastic pressure solve 1",
+        SimpleBounds<4>(primal_topology.ni, primal_topology.n_cells_y,
+                        primal_topology.n_cells_x, primal_topology.nens),
+        YAKL_LAMBDA(int k, int j, int i, int n) {
+          p_transform(k, j, i, n) = -mfvar(0, k + pks, j + pjs, i + pis, n);
+        });
+
+    yakl::timer_start("ffts");
+    fftp_x.forward_real(p_transform);
+    if (ndims > 1) {
+      fftp_y.forward_real(p_transform);
+    }
+    yakl::timer_stop("ffts");
+
+    parallel_for(
+        "Anelastic tridiagonal solve",
+        Bounds<3>(nyf, nxf, primal_topology.nens),
+        YAKL_LAMBDA(int j, int i, int n) {
+          // set the horizontal mean of pressure to zero at k = kfix
+          int ik = i / 2;
+          int jk = j / 2;
+          if (ik == 0 && jk == 0) {
+            p_transform(kfix, j, i, n) = 0;
+          }
+          int nz = primal_topology.ni;
+          tri_c(0, j, i, n) = tri_u(0, j, i, n) / tri_d(0, j, i, n);
+          for (int k = 1; k < nz - 1; ++k) {
+            tri_c(k, j, i, n) =
+                tri_u(k, j, i, n) /
+                (tri_d(k, j, i, n) - tri_l(k, j, i, n) * tri_c(k - 1, j, i, n));
+          }
+          p_transform(0, j, i, n) /= tri_d(0, j, i, n);
+          for (int k = 1; k < nz; ++k) {
+            p_transform(k, j, i, n) =
+                (p_transform(k, j, i, n) -
+                 tri_l(k, j, i, n) * p_transform(k - 1, j, i, n)) /
+                (tri_d(k, j, i, n) - tri_l(k, j, i, n) * tri_c(k - 1, j, i, n));
+          }
+          for (int k = nz - 2; k >= 0; --k) {
+            p_transform(k, j, i, n) -=
+                tri_c(k, j, i, n) * p_transform(k + 1, j, i, n);
+          }
+        });
+
+    yakl::timer_start("ffts");
+    fftp_x.inverse_real(p_transform);
+    if (ndims > 1) {
+      fftp_y.inverse_real(p_transform);
+    }
+    yakl::timer_stop("ffts");
+  }
+
+  void update_velocity(real dt, FieldSet<nprognostic> &rhs,
+                       FieldSet<nconstant> &const_vars,
+                       FieldSet<nauxiliary> &auxiliary_vars,
+                       FieldSet<nprognostic> &solution) override {
+
+    YAKL_SCOPE(primal_geometry, this->primal_geometry);
+    YAKL_SCOPE(dual_geometry, this->dual_geometry);
+    const auto &primal_topology = primal_geometry.topology;
+    const auto &dual_topology = dual_geometry.topology;
+
+    const auto Bvar = auxiliary_vars.fields_arr[BVAR].data;
+    const auto sol_v = solution.fields_arr[VVAR].data;
+    const auto sol_w = solution.fields_arr[WVAR].data;
+
+    const int pis = primal_topology.is;
+    const int pjs = primal_topology.js;
+    const int pks = primal_topology.ks;
+
+    // need to store p into a field with halos
+    parallel_for(
+        "Anelastic update v 1",
+        SimpleBounds<4>(primal_topology.ni, primal_topology.n_cells_y,
+                        primal_topology.n_cells_x, primal_topology.nens),
+        YAKL_LAMBDA(int k, int j, int i, int n) {
+          Bvar(0, k + pks, j + pjs, i + pis, n) = p_transform(k, j, i, n);
+        });
+    auxiliary_vars.exchange({BVAR});
+
+    parallel_for(
+        "Anelastic update v 2",
+        SimpleBounds<4>(primal_topology.nl, primal_topology.n_cells_y,
+                        primal_topology.n_cells_x, primal_topology.nens),
+        YAKL_LAMBDA(int k, int j, int i, int n) {
+          compute_D0_vert<1, ADD_MODE::ADD>(sol_w, Bvar, pis, pjs, pks, i, j, k,
+                                            n);
+        });
+
+    parallel_for(
+        "Anelastic update v 3",
+        SimpleBounds<4>(primal_topology.ni, primal_topology.n_cells_y,
+                        primal_topology.n_cells_x, primal_topology.nens),
+        YAKL_LAMBDA(int k, int j, int i, int n) {
+          compute_D0<1, ADD_MODE::ADD>(sol_v, Bvar, pis, pjs, pks, i, j, k, n);
+        });
+  }
+
+  void update_densities(real dt, FieldSet<nprognostic> &rhs,
+                        FieldSet<nconstant> &const_vars,
+                        FieldSet<nauxiliary> &auxiliary_vars,
+                        FieldSet<nprognostic> &solution) override {}
+};
+
+struct CompressiblePressureLinearSystem : PressureLinearSystem {
+  real3d linp_coeff;
+
+  void initialize(ModelParameters &params,
+                  const Geometry<Straight> &primal_geom,
+                  const Geometry<Twisted> &dual_geom,
+                  Equations &equations) override {
+    PressureLinearSystem::initialize(params, primal_geom, dual_geom, equations);
+    linp_coeff = real3d("linp coeff", VS::ndensity, primal_geometry.topology.ni,
+                        primal_geometry.topology.nens);
+  }
+
+  void compute_coefficients(real dt) override {
     const auto &refstate = this->equations->reference_state;
     const auto &varset = this->equations->varset;
 
@@ -3596,35 +3569,14 @@ public:
         });
   }
 
-  virtual void solve(real dt, FieldSet<nprognostic> &rhs,
-                     FieldSet<nconstant> &const_vars,
-                     FieldSet<nauxiliary> &auxiliary_vars,
-                     FieldSet<nprognostic> &solution) override {
-    yakl::timer_start("linear_solve");
+  void prepare_pressure_rhs(real dt, FieldSet<nprognostic> &rhs,
+                            FieldSet<nconstant> &const_vars,
+                            FieldSet<nauxiliary> &auxiliary_vars) override {
 
-    const auto fvar = auxiliary_vars.fields_arr[FVAR].data;
-    const auto fwvar = auxiliary_vars.fields_arr[FWVAR].data;
-    const auto Bvar = auxiliary_vars.fields_arr[BVAR].data;
-
-    const auto sol_dens = solution.fields_arr[DENSVAR].data;
-    const auto sol_v = solution.fields_arr[VVAR].data;
-    const auto sol_w = solution.fields_arr[WVAR].data;
-
-    const auto rhs_v = rhs.fields_arr[VVAR].data;
-    const auto rhs_w = rhs.fields_arr[WVAR].data;
-    const auto rhs_dens = rhs.fields_arr[DENSVAR].data;
-
+    YAKL_SCOPE(primal_geometry, this->primal_geometry);
+    YAKL_SCOPE(dual_geometry, this->dual_geometry);
     const auto &primal_topology = primal_geometry.topology;
     const auto &dual_topology = dual_geometry.topology;
-    const int pis = primal_topology.is;
-    const int pjs = primal_topology.js;
-    const int pks = primal_topology.ks;
-    const int dis = dual_topology.is;
-    const int djs = dual_topology.js;
-    const int dks = dual_topology.ks;
-
-    YAKL_SCOPE(nxf, this->nxf);
-    YAKL_SCOPE(nyf, this->nyf);
 
     const auto &refstate = this->equations->reference_state;
     const auto &rho_pi = refstate.rho_pi.data;
@@ -3632,15 +3584,21 @@ public:
     const auto &q_pi = refstate.q_pi.data;
     const auto &q_di = refstate.q_di.data;
 
-    YAKL_SCOPE(fftp_x, this->fftp_x);
-    YAKL_SCOPE(fftp_y, this->fftp_y);
-    YAKL_SCOPE(tri_l, this->tri_l);
-    YAKL_SCOPE(tri_u, this->tri_u);
-    YAKL_SCOPE(tri_d, this->tri_d);
-    YAKL_SCOPE(tri_c, this->tri_c);
-    YAKL_SCOPE(p_transform, this->p_transform);
-    YAKL_SCOPE(primal_geometry, this->primal_geometry);
-    YAKL_SCOPE(dual_geometry, this->dual_geometry);
+    const auto Fvar = auxiliary_vars.fields_arr[FVAR].data;
+    const auto FWvar = auxiliary_vars.fields_arr[FWVAR].data;
+    const auto Bvar = auxiliary_vars.fields_arr[BVAR].data;
+    const auto mfvar = auxiliary_vars.fields_arr[MFVAR].data;
+    const auto rhs_v = rhs.fields_arr[VVAR].data;
+    const auto rhs_w = rhs.fields_arr[WVAR].data;
+    const auto rhs_dens = rhs.fields_arr[DENSVAR].data;
+
+    const int pis = primal_topology.is;
+    const int pjs = primal_topology.js;
+    const int pks = primal_topology.ks;
+
+    const int dis = dual_topology.is;
+    const int djs = dual_topology.js;
+    const int dks = dual_topology.ks;
 
     parallel_for(
         "Linear solve rhs 1",
@@ -3652,7 +3610,7 @@ public:
                                    dis, djs, dks, i, j, k, n);
 
           for (int d = 0; d < ndims; ++d) {
-            fvar(d, k + dks, j + djs, i + dis, n) =
+            Fvar(d, k + dks, j + djs, i + dis, n) =
                 u(0, d) * rho_pi(0, k + pks, n);
           }
 
@@ -3660,7 +3618,7 @@ public:
             SArray<real, 1, 1> uw;
             compute_H01(uw, rhs_w, primal_geometry, dual_geometry, dis, djs,
                         dks, i, j, k + 1, n);
-            fwvar(0, k + 1 + dks, j + djs, i + dis, n) =
+            FWvar(0, k + 1 + dks, j + djs, i + dis, n) =
                 uw(0) * rho_di(0, k + dks + 1, n);
           }
         });
@@ -3675,19 +3633,19 @@ public:
           SArray<real, 1, VS::ndensity_prognostic> tend;
           SArray<real, 1, VS::ndensity_prognostic> vtend;
 
-          compute_wDnm1bar<VS::ndensity_prognostic>(tend, q_pi, fvar, dis, djs,
+          compute_wDnm1bar<VS::ndensity_prognostic>(tend, q_pi, Fvar, dis, djs,
                                                     dks, i, j, k, n);
           compute_wDnm1bar_vert<VS::ndensity_prognostic>(
-              vtend, q_di, fwvar, dis, djs, dks, i, j, k, n);
+              vtend, q_di, FWvar, dis, djs, dks, i, j, k, n);
 
           for (int d = 0; d < VS::ndensity_prognostic; ++d) {
-            sol_dens(d, k + dks, j + djs, i + dis, n) =
+            mfvar(d, k + dks, j + djs, i + dis, n) =
                 rhs_dens(d, k + dks, j + djs, i + dis, n);
-            sol_dens(d, k + dks, j + djs, i + dis, n) -= 0.5_fp * dt * tend(d);
-            sol_dens(d, k + dks, j + djs, i + dis, n) -= 0.5_fp * dt * vtend(d);
+            mfvar(d, k + dks, j + djs, i + dis, n) -= 0.5_fp * dt * tend(d);
+            mfvar(d, k + dks, j + djs, i + dis, n) -= 0.5_fp * dt * vtend(d);
           }
         });
-    solution.exchange({DENSVAR});
+    auxiliary_vars.exchange({MFVAR});
 
     parallel_for(
         "Linear solve rhs 3",
@@ -3695,8 +3653,8 @@ public:
                         primal_topology.n_cells_x, primal_topology.nens),
         YAKL_LAMBDA(int k, int j, int i, int n) {
           compute_Hn1bar<VS::ndensity_prognostic, diff_ord, vert_diff_ord>(
-              Bvar, sol_dens, primal_geometry, dual_geometry, pis, pjs, pks, i,
-              j, k, n);
+              Bvar, mfvar, primal_geometry, dual_geometry, pis, pjs, pks, i, j,
+              k, n);
         });
 
     parallel_for(
@@ -3710,6 +3668,22 @@ public:
                 linp_coeff(d, k, n) * Bvar(d, k + pks, j + pjs, i + pis, n);
           }
         });
+  }
+
+  void solve_for_pressure(real dt, FieldSet<nprognostic> &rhs,
+                          FieldSet<nconstant> &const_vars,
+                          FieldSet<nauxiliary> &auxiliary_vars) override {
+
+    YAKL_SCOPE(primal_geometry, this->primal_geometry);
+    YAKL_SCOPE(dual_geometry, this->dual_geometry);
+    const auto &primal_topology = primal_geometry.topology;
+    const auto &dual_topology = dual_geometry.topology;
+
+    const auto mfvar = auxiliary_vars.fields_arr[MFVAR].data;
+
+    const int pis = primal_topology.is;
+    const int pjs = primal_topology.js;
+    const int pks = primal_topology.ks;
 
     yakl::timer_start("ffts");
     fftp_x.forward_real(p_transform);
@@ -3751,6 +3725,35 @@ public:
       fftp_y.inverse_real(p_transform);
     }
     yakl::timer_stop("ffts");
+  }
+
+  void update_velocity(real dt, FieldSet<nprognostic> &rhs,
+                       FieldSet<nconstant> &const_vars,
+                       FieldSet<nauxiliary> &auxiliary_vars,
+                       FieldSet<nprognostic> &solution) override {
+
+    YAKL_SCOPE(primal_geometry, this->primal_geometry);
+    YAKL_SCOPE(dual_geometry, this->dual_geometry);
+    const auto &primal_topology = primal_geometry.topology;
+    const auto &dual_topology = dual_geometry.topology;
+
+    const auto &refstate = this->equations->reference_state;
+    const auto &rho_pi = refstate.rho_pi.data;
+    const auto &rho_di = refstate.rho_di.data;
+
+    const auto Bvar = auxiliary_vars.fields_arr[BVAR].data;
+    const auto rhs_v = rhs.fields_arr[VVAR].data;
+    const auto rhs_w = rhs.fields_arr[WVAR].data;
+    const auto sol_v = solution.fields_arr[VVAR].data;
+    const auto sol_w = solution.fields_arr[WVAR].data;
+
+    const int pis = primal_topology.is;
+    const int pjs = primal_topology.js;
+    const int pks = primal_topology.ks;
+
+    const int dis = dual_topology.is;
+    const int djs = dual_topology.js;
+    const int dks = dual_topology.ks;
 
     parallel_for(
         "Anelastic - store p",
@@ -3788,11 +3791,42 @@ public:
                 0.5_fp * dt * dpdh(0, d) / rho;
           }
         });
+  }
+
+  void update_densities(real dt, FieldSet<nprognostic> &rhs,
+                        FieldSet<nconstant> &const_vars,
+                        FieldSet<nauxiliary> &auxiliary_vars,
+                        FieldSet<nprognostic> &solution) override {
+
+    YAKL_SCOPE(primal_geometry, this->primal_geometry);
+    YAKL_SCOPE(dual_geometry, this->dual_geometry);
+    const auto &primal_topology = primal_geometry.topology;
+    const auto &dual_topology = dual_geometry.topology;
+
+    const auto &refstate = this->equations->reference_state;
+    const auto &rho_pi = refstate.rho_pi.data;
+    const auto &rho_di = refstate.rho_di.data;
+    const auto &q_pi = refstate.q_pi.data;
+    const auto &q_di = refstate.q_di.data;
+
+    const auto rhs_dens = rhs.fields_arr[DENSVAR].data;
+    const auto sol_v = solution.fields_arr[VVAR].data;
+    const auto sol_w = solution.fields_arr[WVAR].data;
+    const auto sol_dens = solution.fields_arr[DENSVAR].data;
+    const auto Fvar = auxiliary_vars.fields_arr[FVAR].data;
+    const auto FWvar = auxiliary_vars.fields_arr[FWVAR].data;
+
+    const int pis = primal_topology.is;
+    const int pjs = primal_topology.js;
+    const int pks = primal_topology.ks;
+
+    const int dis = dual_topology.is;
+    const int djs = dual_topology.js;
+    const int dks = dual_topology.ks;
 
     solution.exchange({VVAR});
     solution.exchange({WVAR});
 
-    YAKL_SCOPE(Hk, this->equations->Hk);
     parallel_for(
         "Recover densities 1 - F/Fw",
         SimpleBounds<4>(dual_topology.nl, dual_topology.n_cells_y,
@@ -3803,7 +3837,7 @@ public:
                                    dis, djs, dks, i, j, k, n);
 
           for (int d = 0; d < ndims; ++d) {
-            fvar(d, k + dks, j + djs, i + dis, n) =
+            Fvar(d, k + dks, j + djs, i + dis, n) =
                 u(0, d) * rho_pi(0, k + pks, n);
           }
 
@@ -3811,7 +3845,7 @@ public:
             SArray<real, 1, 1> uw;
             compute_H01(uw, sol_w, primal_geometry, dual_geometry, dis, djs,
                         dks, i, j, k + 1, n);
-            fwvar(0, k + 1 + dks, j + djs, i + dis, n) =
+            FWvar(0, k + 1 + dks, j + djs, i + dis, n) =
                 uw(0) * rho_di(0, k + dks + 1, n);
           }
         });
@@ -3825,25 +3859,23 @@ public:
         SimpleBounds<4>(dual_topology.nl, dual_topology.n_cells_y,
                         dual_topology.n_cells_x, dual_topology.nens),
         YAKL_LAMBDA(int k, int j, int i, int n) {
-          compute_wDnm1bar<VS::ndensity_prognostic>(sol_dens, q_pi, fvar, dis,
+          compute_wDnm1bar<VS::ndensity_prognostic>(sol_dens, q_pi, Fvar, dis,
                                                     djs, dks, i, j, k, n);
           compute_wDnm1bar_vert<VS::ndensity_prognostic, ADD_MODE::ADD>(
-              sol_dens, q_di, fwvar, dis, djs, dks, i, j, k, n);
+              sol_dens, q_di, FWvar, dis, djs, dks, i, j, k, n);
           for (int d = 0; d < VS::ndensity_prognostic; ++d) {
             sol_dens(d, k + dks, j + djs, i + dis, n) *= -dt / 2;
             sol_dens(d, k + dks, j + djs, i + dis, n) +=
                 rhs_dens(d, pks + k, pjs + j, pis + i, n);
           }
         });
-
-    yakl::timer_stop("linear_solve");
   }
 };
 
 std::unique_ptr<LinearSystem> model_linear_system() {
   if (VariableSet::compressible) {
-    // return std::make_unique<CompressibleLinearSystemVelocity>();
-    return std::make_unique<CompressibleLinearSystemPressure>();
+    // return std::make_unique<CompressibleVelocityLinearSystem>();
+    return std::make_unique<CompressiblePressureLinearSystem>();
   } else {
     return std::make_unique<AnelasticLinearSystem>();
   }

--- a/dynamics/spam/src/models/extrudedmodel.h
+++ b/dynamics/spam/src/models/extrudedmodel.h
@@ -3584,6 +3584,8 @@ struct CompressiblePressureLinearSystem : PressureLinearSystem {
 
     YAKL_SCOPE(primal_geometry, this->primal_geometry);
     YAKL_SCOPE(dual_geometry, this->dual_geometry);
+    YAKL_SCOPE(p_transform, this->p_transform);
+    YAKL_SCOPE(linp_coeff, this->linp_coeff);
     const auto &primal_topology = primal_geometry.topology;
     const auto &dual_topology = dual_geometry.topology;
 
@@ -3685,6 +3687,11 @@ struct CompressiblePressureLinearSystem : PressureLinearSystem {
 
     YAKL_SCOPE(primal_geometry, this->primal_geometry);
     YAKL_SCOPE(dual_geometry, this->dual_geometry);
+    YAKL_SCOPE(p_transform, this->p_transform);
+    YAKL_SCOPE(tri_c, this->tri_c);
+    YAKL_SCOPE(tri_l, this->tri_l);
+    YAKL_SCOPE(tri_u, this->tri_u);
+    YAKL_SCOPE(tri_d, this->tri_d);
     const auto &primal_topology = primal_geometry.topology;
     const auto &dual_topology = dual_geometry.topology;
 
@@ -3743,6 +3750,7 @@ struct CompressiblePressureLinearSystem : PressureLinearSystem {
 
     YAKL_SCOPE(primal_geometry, this->primal_geometry);
     YAKL_SCOPE(dual_geometry, this->dual_geometry);
+    YAKL_SCOPE(p_transform, this->p_transform);
     const auto &primal_topology = primal_geometry.topology;
     const auto &dual_topology = dual_geometry.topology;
 

--- a/dynamics/spam/src/models/extrudedmodel.h
+++ b/dynamics/spam/src/models/extrudedmodel.h
@@ -190,7 +190,7 @@ void add_model_diagnostics(
 }
 
 // Unify interface with ModelLinearSystem
-struct AnelasticPressureSolver {
+struct AnelasticPressureSolver : LinearSystem {
   Geometry<Straight> primal_geometry;
   Geometry<Twisted> dual_geometry;
   Equations *equations;
@@ -245,7 +245,7 @@ struct AnelasticPressureSolver {
     this->is_initialized = true;
   }
 
-  void compute_coefficients() {
+  void compute_coefficients(real dt) {
 
     const auto &refstate = this->equations->reference_state;
 
@@ -332,6 +332,166 @@ struct AnelasticPressureSolver {
           }
         });
   }
+
+  void solve(real dt, FieldSet<nprognostic> &rhs,
+             FieldSet<nconstant> &const_vars,
+             FieldSet<nauxiliary> &auxiliary_vars,
+             FieldSet<nprognostic> &solution) {
+
+    const auto Fvar = auxiliary_vars.fields_arr[FVAR].data;
+    const auto FWvar = auxiliary_vars.fields_arr[FWVAR].data;
+    const auto mfvar = auxiliary_vars.fields_arr[MFVAR].data;
+    const auto Bvar = auxiliary_vars.fields_arr[BVAR].data;
+    const auto sol_v = solution.fields_arr[VVAR].data;
+    const auto sol_w = solution.fields_arr[WVAR].data;
+    const auto rhs_v = rhs.fields_arr[VVAR].data;
+    const auto rhs_w = rhs.fields_arr[WVAR].data;
+
+    const auto &primal_topology = primal_geometry.topology;
+    const auto &dual_topology = dual_geometry.topology;
+    const int pis = primal_topology.is;
+    const int pjs = primal_topology.js;
+    const int pks = primal_topology.ks;
+    const int dis = dual_topology.is;
+    const int djs = dual_topology.js;
+    const int dks = dual_topology.ks;
+
+    YAKL_SCOPE(nxf, this->nxf);
+    YAKL_SCOPE(nyf, this->nyf);
+    YAKL_SCOPE(kfix, this->kfix);
+
+    const auto &refstate = this->equations->reference_state;
+    const auto &rho_pi = refstate.rho_pi.data;
+    const auto &rho_di = refstate.rho_di.data;
+
+    YAKL_SCOPE(fftp_x, this->fftp_x);
+    YAKL_SCOPE(fftp_y, this->fftp_y);
+    YAKL_SCOPE(tri_l, this->tri_l);
+    YAKL_SCOPE(tri_u, this->tri_u);
+    YAKL_SCOPE(tri_d, this->tri_d);
+    YAKL_SCOPE(tri_c, this->tri_c);
+    YAKL_SCOPE(p_transform, this->p_transform);
+    YAKL_SCOPE(primal_geometry, this->primal_geometry);
+    YAKL_SCOPE(dual_geometry, this->dual_geometry);
+    // const auto &q_pi = refstate.q_pi.data;
+    // const auto &q_di = refstate.q_di.data;
+    // const auto &Nsq_pi = refstate.Nsq_pi.data;
+
+    rhs.exchange({VVAR, WVAR});
+
+    // compute rhs
+    parallel_for(
+        "Anelastic F/FW of vel tend",
+        SimpleBounds<4>(dual_topology.nl, dual_topology.n_cells_y,
+                        dual_topology.n_cells_x, dual_topology.nens),
+        YAKL_LAMBDA(int k, int j, int i, int n) {
+          SArray<real, 2, 1, ndims> u;
+          compute_H10<1, diff_ord>(u, rhs_v, primal_geometry, dual_geometry,
+                                   dis, djs, dks, i, j, k, n);
+          for (int d = 0; d < ndims; ++d) {
+            Fvar(d, k + dks, j + djs, i + dis, n) =
+                u(0, d) * rho_pi(0, k + pks, n);
+          }
+
+          if (k < dual_topology.ni - 2) {
+            SArray<real, 1, 1> uw;
+            compute_H01(uw, rhs_w, primal_geometry, dual_geometry, dis, djs,
+                        dks, i, j, k + 1, n);
+            FWvar(0, k + 1 + dks, j + djs, i + dis, n) =
+                uw(0) * rho_di(0, k + dks + 1, n);
+          }
+        });
+    auxiliary_vars.fields_arr[FWVAR].set_bnd(0.0);
+    auxiliary_vars.exchange({FVAR, FWVAR});
+
+    parallel_for(
+        "Anelastic rhs",
+        SimpleBounds<4>(dual_topology.nl, dual_topology.n_cells_y,
+                        dual_topology.n_cells_x, dual_topology.nens),
+        YAKL_LAMBDA(int k, int j, int i, int n) {
+          compute_Dnm1bar<1>(mfvar, Fvar, dis, djs, dks, i, j, k, n);
+          compute_Dnm1bar_vert<1, ADD_MODE::ADD>(mfvar, FWvar, dis, djs, dks, i,
+                                                 j, k, n);
+        });
+
+    parallel_for(
+        "Anelastic p_transform",
+        SimpleBounds<4>(primal_topology.ni, primal_topology.n_cells_y,
+                        primal_topology.n_cells_x, primal_topology.nens),
+        YAKL_LAMBDA(int k, int j, int i, int n) {
+          p_transform(k, j, i, n) = -mfvar(0, k + pks, j + pjs, i + pis, n);
+        });
+
+    yakl::timer_start("ffts");
+    fftp_x.forward_real(p_transform);
+    if (ndims > 1) {
+      fftp_y.forward_real(p_transform);
+    }
+    yakl::timer_stop("ffts");
+
+    parallel_for(
+        "Anelastic tridiagonal solve",
+        Bounds<3>(nyf, nxf, primal_topology.nens),
+        YAKL_LAMBDA(int j, int i, int n) {
+          // set the horizontal mean of pressure to zero at k = kfix
+          int ik = i / 2;
+          int jk = j / 2;
+          if (ik == 0 && jk == 0) {
+            p_transform(kfix, j, i, n) = 0;
+          }
+          int nz = primal_topology.ni;
+          tri_c(0, j, i, n) = tri_u(0, j, i, n) / tri_d(0, j, i, n);
+          for (int k = 1; k < nz - 1; ++k) {
+            tri_c(k, j, i, n) =
+                tri_u(k, j, i, n) /
+                (tri_d(k, j, i, n) - tri_l(k, j, i, n) * tri_c(k - 1, j, i, n));
+          }
+          p_transform(0, j, i, n) /= tri_d(0, j, i, n);
+          for (int k = 1; k < nz; ++k) {
+            p_transform(k, j, i, n) =
+                (p_transform(k, j, i, n) -
+                 tri_l(k, j, i, n) * p_transform(k - 1, j, i, n)) /
+                (tri_d(k, j, i, n) - tri_l(k, j, i, n) * tri_c(k - 1, j, i, n));
+          }
+          for (int k = nz - 2; k >= 0; --k) {
+            p_transform(k, j, i, n) -=
+                tri_c(k, j, i, n) * p_transform(k + 1, j, i, n);
+          }
+        });
+
+    yakl::timer_start("ffts");
+    fftp_x.inverse_real(p_transform);
+    if (ndims > 1) {
+      fftp_y.inverse_real(p_transform);
+    }
+    yakl::timer_stop("ffts");
+
+    parallel_for(
+        "Anelastic - store p",
+        SimpleBounds<4>(primal_topology.ni, primal_topology.n_cells_y,
+                        primal_topology.n_cells_x, primal_topology.nens),
+        YAKL_LAMBDA(int k, int j, int i, int n) {
+          Bvar(0, k + pks, j + pjs, i + pis, n) = p_transform(k, j, i, n);
+        });
+    auxiliary_vars.exchange({BVAR});
+
+    parallel_for(
+        "Anelastic - add pressure gradient W",
+        SimpleBounds<4>(primal_topology.nl, primal_topology.n_cells_y,
+                        primal_topology.n_cells_x, primal_topology.nens),
+        YAKL_LAMBDA(int k, int j, int i, int n) {
+          compute_D0_vert<1, ADD_MODE::ADD>(sol_w, Bvar, pis, pjs, pks, i, j, k,
+                                            n);
+        });
+
+    parallel_for(
+        "Anelastic - add pressure gradient V",
+        SimpleBounds<4>(primal_topology.ni, primal_topology.n_cells_y,
+                        primal_topology.n_cells_x, primal_topology.nens),
+        YAKL_LAMBDA(int k, int j, int i, int n) {
+          compute_D0<1, ADD_MODE::ADD>(sol_v, Bvar, pis, pjs, pks, i, j, k, n);
+        });
+  }
 };
 
 struct TotalDensityFunctor {
@@ -392,7 +552,7 @@ public:
 
 #if defined PAMC_AN || defined PAMC_MAN
     pressure_solver.initialize(params, primal_geom, dual_geom, equations);
-    pressure_solver.compute_coefficients();
+    pressure_solver.compute_coefficients(params.dtcrm);
 #endif
   }
 
@@ -2613,159 +2773,7 @@ public:
                                  FieldSet<nauxiliary> &auxiliary_vars,
                                  FieldSet<nprognostic> &xtend) override {
     yakl::timer_start("add_pressure_perturbation");
-
-    const auto Fvar = auxiliary_vars.fields_arr[FVAR].data;
-    const auto FWvar = auxiliary_vars.fields_arr[FWVAR].data;
-    const auto mfvar = auxiliary_vars.fields_arr[MFVAR].data;
-    const auto Bvar = auxiliary_vars.fields_arr[BVAR].data;
-    const auto Vtendvar = xtend.fields_arr[VVAR].data;
-    const auto Wtendvar = xtend.fields_arr[WVAR].data;
-
-    const auto &primal_topology = primal_geometry.topology;
-    const auto &dual_topology = dual_geometry.topology;
-    const int pis = primal_topology.is;
-    const int pjs = primal_topology.js;
-    const int pks = primal_topology.ks;
-    const int dis = dual_topology.is;
-    const int djs = dual_topology.js;
-    const int dks = dual_topology.ks;
-    const int nxf = pressure_solver.nxf;
-    const int nyf = pressure_solver.nyf;
-    const int kfix = pressure_solver.kfix;
-
-    const auto &refstate = this->equations->reference_state;
-    const auto &rho_pi = refstate.rho_pi.data;
-    const auto &rho_di = refstate.rho_di.data;
-
-    auto &fftp_x = pressure_solver.fftp_x;
-    auto &fftp_y = pressure_solver.fftp_y;
-    const auto &tri_l = pressure_solver.tri_l;
-    const auto &tri_u = pressure_solver.tri_u;
-    const auto &tri_d = pressure_solver.tri_d;
-    const auto &tri_c = pressure_solver.tri_c;
-    YAKL_SCOPE(p_transform, this->pressure_solver.p_transform);
-    YAKL_SCOPE(primal_geometry, this->primal_geometry);
-    YAKL_SCOPE(dual_geometry, this->dual_geometry);
-    // const auto &q_pi = refstate.q_pi.data;
-    // const auto &q_di = refstate.q_di.data;
-    // const auto &Nsq_pi = refstate.Nsq_pi.data;
-
-    xtend.exchange({VVAR, WVAR});
-
-    // compute rhs
-    parallel_for(
-        "Anelastic F/FW of vel tend",
-        SimpleBounds<4>(dual_topology.nl, dual_topology.n_cells_y,
-                        dual_topology.n_cells_x, dual_topology.nens),
-        YAKL_LAMBDA(int k, int j, int i, int n) {
-          SArray<real, 2, 1, ndims> u;
-          compute_H10<1, diff_ord>(u, Vtendvar, primal_geometry, dual_geometry,
-                                   dis, djs, dks, i, j, k, n);
-          for (int d = 0; d < ndims; ++d) {
-            Fvar(d, k + dks, j + djs, i + dis, n) =
-                u(0, d) * rho_pi(0, k + pks, n);
-          }
-
-          if (k < dual_topology.ni - 2) {
-            SArray<real, 1, 1> uw;
-            compute_H01(uw, Wtendvar, primal_geometry, dual_geometry, dis, djs,
-                        dks, i, j, k + 1, n);
-            FWvar(0, k + 1 + dks, j + djs, i + dis, n) =
-                uw(0) * rho_di(0, k + dks + 1, n);
-          }
-        });
-    auxiliary_vars.fields_arr[FWVAR].set_bnd(0.0);
-    auxiliary_vars.exchange({FVAR, FWVAR});
-
-    parallel_for(
-        "Anelastic rhs",
-        SimpleBounds<4>(dual_topology.nl, dual_topology.n_cells_y,
-                        dual_topology.n_cells_x, dual_topology.nens),
-        YAKL_LAMBDA(int k, int j, int i, int n) {
-          compute_Dnm1bar<1>(mfvar, Fvar, dis, djs, dks, i, j, k, n);
-          compute_Dnm1bar_vert<1, ADD_MODE::ADD>(mfvar, FWvar, dis, djs, dks, i,
-                                                 j, k, n);
-        });
-
-    parallel_for(
-        "Anelastic p_transform",
-        SimpleBounds<4>(primal_topology.ni, primal_topology.n_cells_y,
-                        primal_topology.n_cells_x, primal_topology.nens),
-        YAKL_LAMBDA(int k, int j, int i, int n) {
-          p_transform(k, j, i, n) = -mfvar(0, k + pks, j + pjs, i + pis, n);
-        });
-
-    yakl::timer_start("ffts");
-    fftp_x.forward_real(p_transform);
-    if (ndims > 1) {
-      fftp_y.forward_real(p_transform);
-    }
-    yakl::timer_stop("ffts");
-
-    parallel_for(
-        "Anelastic tridiagonal solve",
-        Bounds<3>(nyf, nxf, primal_topology.nens),
-        YAKL_LAMBDA(int j, int i, int n) {
-          // set the horizontal mean of pressure to zero at k = kfix
-          int ik = i / 2;
-          int jk = j / 2;
-          if (ik == 0 && jk == 0) {
-            p_transform(kfix, j, i, n) = 0;
-          }
-          int nz = primal_topology.ni;
-          tri_c(0, j, i, n) = tri_u(0, j, i, n) / tri_d(0, j, i, n);
-          for (int k = 1; k < nz - 1; ++k) {
-            tri_c(k, j, i, n) =
-                tri_u(k, j, i, n) /
-                (tri_d(k, j, i, n) - tri_l(k, j, i, n) * tri_c(k - 1, j, i, n));
-          }
-          p_transform(0, j, i, n) /= tri_d(0, j, i, n);
-          for (int k = 1; k < nz; ++k) {
-            p_transform(k, j, i, n) =
-                (p_transform(k, j, i, n) -
-                 tri_l(k, j, i, n) * p_transform(k - 1, j, i, n)) /
-                (tri_d(k, j, i, n) - tri_l(k, j, i, n) * tri_c(k - 1, j, i, n));
-          }
-          for (int k = nz - 2; k >= 0; --k) {
-            p_transform(k, j, i, n) -=
-                tri_c(k, j, i, n) * p_transform(k + 1, j, i, n);
-          }
-        });
-
-    yakl::timer_start("ffts");
-    fftp_x.inverse_real(p_transform);
-    if (ndims > 1) {
-      fftp_y.inverse_real(p_transform);
-    }
-    yakl::timer_stop("ffts");
-
-    parallel_for(
-        "Anelastic - store p",
-        SimpleBounds<4>(primal_topology.ni, primal_topology.n_cells_y,
-                        primal_topology.n_cells_x, primal_topology.nens),
-        YAKL_LAMBDA(int k, int j, int i, int n) {
-          Bvar(0, k + pks, j + pjs, i + pis, n) = p_transform(k, j, i, n);
-        });
-    auxiliary_vars.exchange({BVAR});
-
-    parallel_for(
-        "Anelastic - add pressure gradient W",
-        SimpleBounds<4>(primal_topology.nl, primal_topology.n_cells_y,
-                        primal_topology.n_cells_x, primal_topology.nens),
-        YAKL_LAMBDA(int k, int j, int i, int n) {
-          compute_D0_vert<1, ADD_MODE::ADD>(Wtendvar, Bvar, pis, pjs, pks, i, j,
-                                            k, n);
-        });
-
-    parallel_for(
-        "Anelastic - add pressure gradient V",
-        SimpleBounds<4>(primal_topology.ni, primal_topology.n_cells_y,
-                        primal_topology.n_cells_x, primal_topology.nens),
-        YAKL_LAMBDA(int k, int j, int i, int n) {
-          compute_D0<1, ADD_MODE::ADD>(Vtendvar, Bvar, pis, pjs, pks, i, j, k,
-                                       n);
-        });
-
+    pressure_solver.solve(dt, xtend, const_vars, auxiliary_vars, xtend);
     yakl::timer_stop("add_pressure_perturbation");
   }
 #endif

--- a/dynamics/spam/src/models/layermodel.h
+++ b/dynamics/spam/src/models/layermodel.h
@@ -885,7 +885,8 @@ public:
   }
 };
 
-std::unique_ptr<LinearSystem> model_linear_system() {
+std::unique_ptr<LinearSystem>
+model_linear_system(const ModelParameters &params) {
   return std::make_unique<ModelLinearSystem>();
 }
 

--- a/dynamics/spam/src/models/layermodel.h
+++ b/dynamics/spam/src/models/layermodel.h
@@ -95,10 +95,12 @@ public:
   using VS = VariableSet;
 
   void initialize(ModelParameters &params, Equations &equations,
+                  LinearSystem &linear_system,
                   const Geometry<Straight> &primal_geom,
                   const Geometry<Twisted> &dual_geom) {
 
-    Tendencies::initialize(params, equations, primal_geom, dual_geom);
+    Tendencies::initialize(params, equations, linear_system, primal_geom,
+                           dual_geom);
   }
 
   void convert_dynamics_to_coupler_state(PamCoupler &coupler,
@@ -882,6 +884,10 @@ public:
     yakl::timer_stop("linear_solve");
   }
 };
+
+std::unique_ptr<LinearSystem> model_linear_system() {
+  return std::make_unique<ModelLinearSystem>();
+}
 
 // *******   Statistics   ***********//
 

--- a/dynamics/spam/src/timesteppers/KGRK.h
+++ b/dynamics/spam/src/timesteppers/KGRK.h
@@ -24,10 +24,9 @@ public:
   void set_stage_coefficients(ModelParameters &params);
 
   void initialize(ModelParameters &params, Tendencies &tend,
-                  LinearSystem &linsys, FieldSet<nprognostic> &xvars,
-                  FieldSet<nconstant> &consts,
+                  FieldSet<nprognostic> &xvars, FieldSet<nconstant> &consts,
                   FieldSet<nauxiliary> &auxiliarys) override {
-    TimeIntegrator::initialize(params, tend, linsys, xvars, consts, auxiliarys);
+    TimeIntegrator::initialize(params, tend, xvars, consts, auxiliarys);
 
     this->xtemp.initialize(xvars, "xtemp");
     this->xtend.initialize(xvars, "xtend");

--- a/dynamics/spam/src/timesteppers/LSRK.h
+++ b/dynamics/spam/src/timesteppers/LSRK.h
@@ -19,10 +19,9 @@ public:
   int nstages;
 
   void initialize(ModelParameters &params, Tendencies &tend,
-                  LinearSystem &linsys, FieldSet<nprognostic> &xvars,
-                  FieldSet<nconstant> &consts,
+                  FieldSet<nprognostic> &xvars, FieldSet<nconstant> &consts,
                   FieldSet<nauxiliary> &auxiliarys) override {
-    TimeIntegrator::initialize(params, tend, linsys, xvars, consts, auxiliarys);
+    TimeIntegrator::initialize(params, tend, xvars, consts, auxiliarys);
 
     this->dx.initialize(xvars, "dx");
     this->is_ssp = false;

--- a/dynamics/spam/src/timesteppers/SI_Fixed.h
+++ b/dynamics/spam/src/timesteppers/SI_Fixed.h
@@ -21,11 +21,10 @@ public:
   FieldSet<nprognostic> xm;
 
   void initialize(ModelParameters &params, Tendencies &tend,
-                  LinearSystem &linsys, FieldSet<nprognostic> &xvars,
-                  FieldSet<nconstant> &consts,
+                  FieldSet<nprognostic> &xvars, FieldSet<nconstant> &consts,
                   FieldSet<nauxiliary> &auxiliarys) override {
 
-    SemiImplicitTimeIntegrator::initialize(params, tend, linsys, xvars, consts,
+    SemiImplicitTimeIntegrator::initialize(params, tend, xvars, consts,
                                            auxiliarys);
 
     this->dx.initialize(xvars, "dx");

--- a/dynamics/spam/src/timesteppers/SI_Newton.h
+++ b/dynamics/spam/src/timesteppers/SI_Newton.h
@@ -19,20 +19,17 @@ public:
   FieldSet<nprognostic> dx;
   FieldSet<nprognostic> xn;
   FieldSet<nprognostic> xm;
-  LinearSystem *linear_system;
 
   void initialize(ModelParameters &params, Tendencies &tend,
-                  LinearSystem &linsys, FieldSet<nprognostic> &xvars,
-                  FieldSet<nconstant> &consts,
+                  FieldSet<nprognostic> &xvars, FieldSet<nconstant> &consts,
                   FieldSet<nauxiliary> &auxiliarys) override {
 
-    SemiImplicitTimeIntegrator::initialize(params, tend, linsys, xvars, consts,
+    SemiImplicitTimeIntegrator::initialize(params, tend, xvars, consts,
                                            auxiliarys);
 
     this->dx.initialize(xvars, "dx");
     this->xn.initialize(xvars, "xn");
     this->xm.initialize(xvars, "xm");
-    this->linear_system = &linsys;
 
     this->step = 0;
     this->avg_iters = 0;
@@ -75,8 +72,8 @@ public:
         break;
       }
 
-      this->linear_system->solve(dt, this->xm, *this->const_vars,
-                                 *this->auxiliary_vars, this->dx);
+      this->tendencies->linear_system->solve(dt, this->xm, *this->const_vars,
+                                             *this->auxiliary_vars, this->dx);
 
       this->xn.waxpy(1, this->dx, this->xn);
 

--- a/dynamics/spam/src/timesteppers/SSPRK.h
+++ b/dynamics/spam/src/timesteppers/SSPRK.h
@@ -19,10 +19,9 @@ public:
   std::vector<FieldSet<nprognostic>> xstage;
 
   void initialize(ModelParameters &params, Tendencies &tend,
-                  LinearSystem &linsys, FieldSet<nprognostic> &xvars,
-                  FieldSet<nconstant> &consts,
+                  FieldSet<nprognostic> &xvars, FieldSet<nconstant> &consts,
                   FieldSet<nauxiliary> &auxiliarys) override {
-    TimeIntegrator::initialize(params, tend, linsys, xvars, consts, auxiliarys);
+    TimeIntegrator::initialize(params, tend, xvars, consts, auxiliarys);
 
     if (tstype == "ssprk2") {
       this->nstages = 2;

--- a/standalone/mmf_simplified/inputs/pamc_idealized/pamc_input_extruded_supercell.yaml
+++ b/standalone/mmf_simplified/inputs/pamc_idealized/pamc_input_extruded_supercell.yaml
@@ -5,6 +5,8 @@ force_refstate_hydrostatic_balance : true
 velocity_diffusion_subtract_refstate : true
 couple_wind : false
 couple_wind_exact_inverse : true
+si_monitor_convergence : 1
+si_max_iters : 5
 
 # Simulation time in seconds
 sim_time : 7200


### PR DESCRIPTION
This PR adds two new linear systems that enable semi-implicit time integration of compressible equations in 3d. Both solvers are pressure-based. One of them treats gravity waves implicitly. The old velocity-based solver that works only in 2D is retained. The solver can be now configured at runtime and defaults to the pressure solver without implicit treatment of gravity waves.

The extruded model is getting too big and needs to be split into multiple files. To avoid annoying git conflicts I think this change should be done once this and the hyperdiffusion PR are merged.
