### PR TITLE
Both p3_main and shoc_main added a Runtime paramter

### DIFF
--- a/physics/scream_cxx_interfaces/scream_cxx_interface_p3.cpp
+++ b/physics/scream_cxx_interfaces/scream_cxx_interface_p3.cpp
@@ -228,7 +228,10 @@ namespace pam {
 
     p3_main_cxx_mutex.unlock();
 
-    P3F::P3Runtime runtime_options;
+    // hardcode runtime options to match f90 settings for now
+    P3F::P3Runtime runtime_options{
+      500.e+3 // max_total_ni
+    };
 
     const int nlev_pack = ekat::npack<Spack>(nlev);
     const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(ncol, nlev_pack);

--- a/physics/scream_cxx_interfaces/scream_cxx_interface_p3.cpp
+++ b/physics/scream_cxx_interfaces/scream_cxx_interface_p3.cpp
@@ -228,9 +228,9 @@ namespace pam {
 
     p3_main_cxx_mutex.unlock();
 
-    // hardcode runtime options to match f90 settings for now
+    // hardcode runtime options to match common scream settings for now
     P3F::P3Runtime runtime_options{
-      500.e+3 // max_total_ni
+      740.0e3 // max_total_ni
     };
 
     const int nlev_pack = ekat::npack<Spack>(nlev);

--- a/physics/scream_cxx_interfaces/scream_cxx_interface_p3.cpp
+++ b/physics/scream_cxx_interfaces/scream_cxx_interface_p3.cpp
@@ -228,11 +228,13 @@ namespace pam {
 
     p3_main_cxx_mutex.unlock();
 
+    P3F::P3Runtime runtime_options;
+
     const int nlev_pack = ekat::npack<Spack>(nlev);
     const auto policy = ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(ncol, nlev_pack);
     ekat::WorkspaceManager<Spack, KT::Device> workspace_mgr(nlev_pack, 59, policy);
 
-    auto elapsed_time = P3F::p3_main(prog_state, diag_inputs, diag_outputs, infrastructure,
+    auto elapsed_time = P3F::p3_main(runtime_options, prog_state, diag_inputs, diag_outputs, infrastructure,
                                      history_only, lookup_tables, workspace_mgr, ncol, nlev);
   }
 

--- a/physics/scream_cxx_interfaces/scream_cxx_interface_shoc.cpp
+++ b/physics/scream_cxx_interfaces/scream_cxx_interface_shoc.cpp
@@ -177,6 +177,7 @@ namespace pam {
 
     //--------------------------------------------------------------------------
 
+    // hardcode runtime options to match common scream settings for now
     SHOC::SHOCRuntime shoc_runtime_options {
         0.001, // lambda_low
         0.04, // lambda_high

--- a/physics/scream_cxx_interfaces/scream_cxx_interface_shoc.cpp
+++ b/physics/scream_cxx_interfaces/scream_cxx_interface_shoc.cpp
@@ -177,13 +177,15 @@ namespace pam {
 
     //--------------------------------------------------------------------------
 
+    SHOC::SHOCRuntime shoc_runtime_options;
+
     const int nwind = ekat::npack<Spack>(2)*Spack::n;
     const int ntrac = ekat::npack<Spack>(num_qtracers+3)*Spack::n;
     const auto policy = ekat::ExeSpaceUtils<SHOC::KT::ExeSpace>::get_default_team_policy(ncol, npack);
     ekat::WorkspaceManager<Spack, SHOC::KT::Device> workspace_mgr(nipack, 13+(nwind+ntrac), policy);
 
     const auto elapsed_microsec = SHOC::shoc_main(shcol, nlev, nlevi, nlev, nadv, num_qtracers, dtime, workspace_mgr,
-                                                  shoc_input, shoc_input_output, shoc_output, shoc_history_output);
+                                                  shoc_runtime_options, shoc_input, shoc_input_output, shoc_output, shoc_history_output);
   }
 
 }

--- a/physics/scream_cxx_interfaces/scream_cxx_interface_shoc.cpp
+++ b/physics/scream_cxx_interfaces/scream_cxx_interface_shoc.cpp
@@ -177,7 +177,20 @@ namespace pam {
 
     //--------------------------------------------------------------------------
 
-    SHOC::SHOCRuntime shoc_runtime_options;
+    SHOC::SHOCRuntime shoc_runtime_options {
+        0.001, // lambda_low
+        0.04, // lambda_high
+        2.65, // lambda_slope
+        0.02, // lambda_thresh
+        1.0, // thl2tune
+        1.0, // qw2tune
+        1.0, // qwthl2tune
+        1.0, // w2tune
+        0.5, // length_fac
+        7.0, // c_diag_3rd_mom
+        0.1, // Ckh
+        0.1 // Ckm
+    };
 
     const int nwind = ekat::npack<Spack>(2)*Spack::n;
     const int ntrac = ekat::npack<Spack>(num_qtracers+3)*Spack::n;


### PR DESCRIPTION
We need to discuss what values to set in the Runtime objects.


P3Runtime has:
`Scalar max_total_ni;`

SHOCRuntime has:
```
   Scalar lambda_low;
   Scalar lambda_high;
   Scalar lambda_slope;
   Scalar lambda_thresh;
   Scalar thl2tune;
   Scalar qw2tune;
   Scalar qwthl2tune;
   Scalar w2tune;
   Scalar length_fac;
   Scalar c_diag_3rd_mom;
   Scalar Ckh;
   Scalar Ckm;
```