### PR TITLE
add update_dt method for SPAM

### DIFF
--- a/dynamics/spam/Dycore.h
+++ b/dynamics/spam/Dycore.h
@@ -231,7 +231,9 @@ public:
   }
 
   void update_dt(pam::PamCoupler &coupler) {
-    params.dt_crm_phys = coupler.get_option<real>("crm_dt");
+    if (params.tstype != "si") {
+      params.dt_crm_phys = coupler.get_option<real>("crm_dt");
+    }
   }
 
   // Given the model data and CFL value, compute the maximum stable time step

--- a/dynamics/spam/Dycore.h
+++ b/dynamics/spam/Dycore.h
@@ -231,10 +231,13 @@ public:
   }
 
   void update_dt(pam::PamCoupler &coupler) {
-    if (params.tstype != "si") {
-      params.dt_crm_phys = coupler.get_option<real>("crm_dt");
-      params.dtcrm = params.dt_crm_phys / params.crm_per_phys;
+    if (params.tstype=="si") {
+      serial_print("ERROR - update_dt: time step cannot be updated in SI mode", par.masterproc);
+      exit(-1);
     }
+    params.dt_crm_phys = coupler.get_option<real>("crm_dt");
+    params.dtcrm = params.dt_crm_phys / params.crm_per_phys;
+    
   }
 
   // Given the model data and CFL value, compute the maximum stable time step

--- a/dynamics/spam/Dycore.h
+++ b/dynamics/spam/Dycore.h
@@ -230,6 +230,10 @@ public:
     prevstep = 1;
   }
 
+  void update_dt(pam::PamCoupler &coupler) {
+    params.dt_crm_phys = coupler.get_option<real>("crm_dt");
+  }
+
   // Given the model data and CFL value, compute the maximum stable time step
   real compute_time_step(PamCoupler const &coupler, real cfl_in = -1) {
     return 0._fp;

--- a/dynamics/spam/Dycore.h
+++ b/dynamics/spam/Dycore.h
@@ -233,6 +233,7 @@ public:
   void update_dt(pam::PamCoupler &coupler) {
     if (params.tstype != "si") {
       params.dt_crm_phys = coupler.get_option<real>("crm_dt");
+      params.dtcrm = params.dt_crm_phys / params.crm_per_phys;
     }
   }
 


### PR DESCRIPTION
This method is used for subcycling in the PAM driver in the MMF