### PR TITLE
Update scream_cxx_interface_shoc.cpp

### DIFF
--- a/physics/scream_cxx_interfaces/scream_cxx_interface_shoc.cpp
+++ b/physics/scream_cxx_interfaces/scream_cxx_interface_shoc.cpp
@@ -1,8 +1,6 @@
 
 #include "EKAT_utils.h"
 #include "shoc_functions.hpp"
-#include "shoc_functions_f90.hpp"
-#include "shoc_f90.hpp"
 
 namespace pam {
 


### PR DESCRIPTION
the *f90* files were removed from SCREAM so we need to remove the include statements for these in the SHOC interface