### PR TITLE
Do NOT generate headers in the source code

### DIFF
--- a/physics/scream_cxx_interfaces/CMakeLists.txt
+++ b/physics/scream_cxx_interfaces/CMakeLists.txt
@@ -67,8 +67,8 @@ macro (EkatConfigFile CONFIG_FILE_IN CONFIG_FILE_C EKAT_CONFIGURE_FILE_F90_FILE)
 endmacro (EkatConfigFile)
 
 EkatConfigFile(${SCREAM_HOME}/components/eamxx/src/scream_config.h.in
-               ${SCREAM_HOME}/components/eamxx/src/scream_config.h
-               ${SCREAM_HOME}/components/eamxx/src/scream_config.f)
+               ${CMAKE_CURRENT_BINARY_DIR}/scream_config.h
+               ${CMAKE_CURRENT_BINARY_DIR}/scream_config.f)
 
 include_directories(${SCREAM_HOME}/components/eamxx/src/physics/shoc     )
 include_directories(${SCREAM_HOME}/components/eamxx/src/physics/shoc/impl)
@@ -76,6 +76,7 @@ include_directories(${SCREAM_HOME}/components/eamxx/src/physics/p3       )
 include_directories(${SCREAM_HOME}/components/eamxx/src/physics/p3/impl  )
 include_directories(${SCREAM_HOME}/components/eamxx/src/physics/share    )
 include_directories(${SCREAM_HOME}/components/eamxx/src                  )
+include_directories(${CMAKE_CURRENT_BINARY_DIR}                          )
 include_directories(${YAKL_HOME}/external                                )
 
 if (PAM_STANDALONE)

--- a/physics/scream_cxx_p3_shoc/CMakeLists.txt
+++ b/physics/scream_cxx_p3_shoc/CMakeLists.txt
@@ -59,9 +59,10 @@ macro (EkatConfigFile CONFIG_FILE_IN CONFIG_FILE_C EKAT_CONFIGURE_FILE_F90_FILE)
   #                 ECHO_OUTPUT_VARIABLE ${TMP} )
 endmacro (EkatConfigFile)
 
+
 EkatConfigFile(${SCREAM_HOME}/components/eamxx/src/scream_config.h.in
-               ${SCREAM_HOME}/components/eamxx/src/scream_config.h
-               ${SCREAM_HOME}/components/eamxx/src/scream_config.f)
+               ${CMAKE_CURRENT_BINARY_DIR}/scream_config.h
+               ${CMAKE_CURRENT_BINARY_DIR}/scream_config.f)
 
 if (${USE_KOKKOS})
    set(Kokkos_ROOT ${INSTALL_SHAREDPATH}/kokkos/build)
@@ -73,6 +74,7 @@ include_directories(${SCREAM_HOME}/components/eamxx/src/physics/p3       )
 include_directories(${SCREAM_HOME}/components/eamxx/src/physics/p3/impl  )
 include_directories(${SCREAM_HOME}/components/eamxx/src/physics/share    )
 include_directories(${SCREAM_HOME}/components/eamxx/src                  )
+include_directories(${CMAKE_CURRENT_BINARY_DIR}                          )
 include_directories(${SCREAM_HOME}/components/eam/src/physics/cam        )
 include_directories(${SCREAM_HOME}/share/timing                          )
 include_directories(${YAKL_HOME}/external                                )


### PR DESCRIPTION
This changes the behavior of every subsequent case, which will pick up the scream_config.h header in the source code before the one in the binary dir. This can lead to very confusing errors.

I confirmed that the test case `SMS_Ln3.ne4pg2_oQU480.F2010-MMF2` was adding scream_config.h and scream_config.f headers to the source directory. With this change, the test still builds and does not put headers there.