### PR TITLE
Remove eamxx_physics target

### DIFF
--- a/physics/scream_cxx_p3_shoc/CMakeLists.txt
+++ b/physics/scream_cxx_p3_shoc/CMakeLists.txt
@@ -79,7 +79,6 @@ include_directories(${SCREAM_HOME}/components/eam/src/physics/cam        )
 include_directories(${SCREAM_HOME}/share/timing                          )
 include_directories(${YAKL_HOME}/external                                )
 
-add_library(eamxx_physics INTERFACE)
 add_subdirectory(${SCREAM_HOME}/externals/ekat                     ${EKAT_BINARY_DIR}                       )
 add_subdirectory(scream_share                                      ${CMAKE_CURRENT_BINARY_DIR}/scream_share )
 add_subdirectory(${SCREAM_HOME}/components/eamxx/src/physics/share ${CMAKE_CURRENT_BINARY_DIR}/physics_share)


### PR DESCRIPTION
It is unused here, and causes a name clash when pam is used in E3SM. The same target is declared in e3sm's crm cmake machinery.