### PR TITLE
Correctly set scream_data_dir in scream_cxx_p3_shoc folder

### DIFF
--- a/physics/scream_cxx_p3_shoc/CMakeLists.txt
+++ b/physics/scream_cxx_p3_shoc/CMakeLists.txt
@@ -44,6 +44,17 @@ set(SCREAM_SMALL_PACK_SIZE         1           CACHE BOOL "" FORCE)
 set(SCREAM_NUM_VERTICAL_LEV        ${PAM_NLEV} CACHE BOOL "" FORCE)
 if (PAM_STANDALONE)
   set(SCREAM_DATA_DIR                ${CMAKE_CURRENT_SOURCE_DIR}/../micro/p3)
+else()
+  # MACH comes from CIME build system
+  execute_process(COMMAND ${SCREAM_HOME}/components/eamxx/scripts/query-cime ${MACH} DIN_LOC_ROOT
+    RESULT_VARIABLE QC_STATUS
+    OUTPUT_VARIABLE QC_OUTPUT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  if (QC_STATUS EQUAL 0)
+    set(SCREAM_INPUT_ROOT ${QC_OUTPUT} CACHE PATH "" FORCE )
+  endif()
+  set (SCREAM_DATA_DIR ${SCREAM_INPUT_ROOT}/atm/scream CACHE PATH "" FORCE)
 endif()
 
 macro (EkatConfigFile CONFIG_FILE_IN CONFIG_FILE_C EKAT_CONFIGURE_FILE_F90_FILE)


### PR DESCRIPTION
Otherwise, the scream_config.h file won't contain a valid entry.

NOTE: before we fixed an issue with scream_config generation, the generated files always ended up in components/eamxx/src, which was always included, and therefore all pam targets could see this file. However, now, each PAM target runs its own configure_file call, with a different file in their bin folders. This PR makes sure they all generated the same (and therefore it doesn't matter that there are many or one). In particular, one of the generated files had no SCREAM_DATA_DIR defined, resulting in an ill-formed p3 table filename.

Note: I don't know PAM well enough, but I suspect it'd be easier to handle the creation of the config.h files once, from a parent folder. But I don't know which folders are actually used in all use cases (PAM standalone and in e3sm), so I'll just do the quick fix for now. This got the MMF2 case that eamxx CI runs in the e3sm repo to work when I manually ran it in the ghci-snl-cpu container.