### PR TITLE
De-scream some file names in PAM

### DIFF
--- a/physics/scream_cxx_interfaces/CMakeLists.txt
+++ b/physics/scream_cxx_interfaces/CMakeLists.txt
@@ -66,9 +66,9 @@ macro (EkatConfigFile CONFIG_FILE_IN CONFIG_FILE_C EKAT_CONFIGURE_FILE_F90_FILE)
   #                 ECHO_OUTPUT_VARIABLE ${TMP} )
 endmacro (EkatConfigFile)
 
-EkatConfigFile(${SCREAM_HOME}/components/eamxx/src/scream_config.h.in
-               ${CMAKE_CURRENT_BINARY_DIR}/scream_config.h
-               ${CMAKE_CURRENT_BINARY_DIR}/scream_config.f)
+EkatConfigFile(${SCREAM_HOME}/components/eamxx/src/eamxx_config.h.in
+               ${CMAKE_CURRENT_BINARY_DIR}/eamxx_config.h
+               ${CMAKE_CURRENT_BINARY_DIR}/eamxx_config.f)
 
 include_directories(${SCREAM_HOME}/components/eamxx/src/physics/shoc     )
 include_directories(${SCREAM_HOME}/components/eamxx/src/physics/shoc/impl)

--- a/physics/scream_cxx_interfaces/EKAT_utils.h
+++ b/physics/scream_cxx_interfaces/EKAT_utils.h
@@ -7,7 +7,7 @@
 #include "ekat/ekat_assert.hpp"
 #include "ekat/ekat_session.hpp"
 #include "ArrayIR.h"
-#include "share/scream_types.hpp"
+#include "share/eamxx_types.hpp"
 
 // for kokkos debuge only
 #if defined(DEBUG)

--- a/physics/scream_cxx_p3_shoc/CMakeLists.txt
+++ b/physics/scream_cxx_p3_shoc/CMakeLists.txt
@@ -71,9 +71,9 @@ macro (EkatConfigFile CONFIG_FILE_IN CONFIG_FILE_C EKAT_CONFIGURE_FILE_F90_FILE)
 endmacro (EkatConfigFile)
 
 
-EkatConfigFile(${SCREAM_HOME}/components/eamxx/src/scream_config.h.in
-               ${CMAKE_CURRENT_BINARY_DIR}/scream_config.h
-               ${CMAKE_CURRENT_BINARY_DIR}/scream_config.f)
+EkatConfigFile(${SCREAM_HOME}/components/eamxx/src/eamxx_config.h.in
+               ${CMAKE_CURRENT_BINARY_DIR}/eamxx_config.h
+               ${CMAKE_CURRENT_BINARY_DIR}/eamxx_config.f)
 
 if (${USE_KOKKOS})
    set(Kokkos_ROOT ${INSTALL_SHAREDPATH}/kokkos/build)

--- a/physics/scream_cxx_p3_shoc/scream_share/CMakeLists.txt
+++ b/physics/scream_cxx_p3_shoc/scream_share/CMakeLists.txt
@@ -1,11 +1,11 @@
 include (EkatSetCompilerFlags)
 
 set(SHARE_SRC
-  ${SCREAM_HOME}/components/eamxx/src/share/scream_config.cpp
-  ${SCREAM_HOME}/components/eamxx/src/share/scream_session.cpp
-  ${SCREAM_HOME}/components/eamxx/src/share/util/scream_time_stamp.cpp
-  ${SCREAM_HOME}/components/eamxx/src/share/util/scream_timing.cpp
-  ${SCREAM_HOME}/components/eamxx/src/share/util/scream_utils.cpp
+  ${SCREAM_HOME}/components/eamxx/src/share/eamxx_config.cpp
+  ${SCREAM_HOME}/components/eamxx/src/share/eamxx_session.cpp
+  ${SCREAM_HOME}/components/eamxx/src/share/util/eamxx_time_stamp.cpp
+  ${SCREAM_HOME}/components/eamxx/src/share/util/eamxx_timing.cpp
+  ${SCREAM_HOME}/components/eamxx/src/share/util/eamxx_utils.cpp
 )
 
 add_library(scream_share ${SHARE_SRC})
@@ -22,7 +22,7 @@ target_compile_options(scream_share PUBLIC
   $<$<COMPILE_LANGUAGE:Fortran>:${SCREAM_Fortran_FLAGS}>
 )
 
-# This used to be in `scream_config.h/scream_config.f`, but we did accidentally remove
+# This used to be in `eamxx_config.h/eamxx_config.f`, but we did accidentally remove
 # the includes at least twice. To avoid this from happening again, we add this crucial
 # macro as a compile definition of the scream_share, which is linked to all other
 # scream libraries.


### PR DESCRIPTION
We are trying to move away from file names with "scream" in them in eamxx. PAM was using a few of these. Do not merge this until https://github.com/E3SM-Project/E3SM/pull/7045 is merged.